### PR TITLE
[SRK-2] Remake `concatMapM`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 * [#25](https://github.com/serokell/universum/issues/25):
   Add vararg functions composition operator (...).
+* Rewrite `concatMapM` & `concatForM` so that they allow traversed
+  and returned-by-function container types differ.
 
 0.4.1
 =====

--- a/src/Monad.hs
+++ b/src/Monad.hs
@@ -87,6 +87,21 @@ import           Containers                      (Element, NontrivialContainer, 
 -- @
 --     concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
 -- @
+--
+-- Side note: previously it had type
+--
+-- @
+--     concatMapM :: (Applicative q, Monad m, Traversable m)
+--                => (a -> q (m b)) -> m a -> q (m b)
+-- @
+--
+-- Such signature didn't allow to use this function when traversed container
+-- type and type of returned by function-argument differed.
+-- Now you can use it like e.g.
+--
+-- @
+--     concatMapM readFile files >>= putStrLn
+-- @
 concatMapM
     :: ( Applicative f
        , Monoid m

--- a/universum.cabal
+++ b/universum.cabal
@@ -1,5 +1,5 @@
 name:                universum
-version:             0.4.1
+version:             0.4.2
 synopsis:            Custom prelude used in Serokell
 description:         Custom prelude used in Serokell
 homepage:            https://github.com/serokell/universum


### PR DESCRIPTION
Previously it didn't work if containers of different types were invoked,
now it allows to e.g. traverse list and concat resulting d-lists.