### PR TITLE
Use TypeNats instead of TypeLits when possible

### DIFF
--- a/src/Base.hs
+++ b/src/Base.hs
@@ -14,7 +14,11 @@ module Base
        , module GHC.Num
        , module GHC.Real
        , module GHC.Show
+#if MIN_VERSION_base(4,10,0)
+       , module GHC.TypeNats
+#else
        , module GHC.TypeLits
+#endif
        , module GHC.Types
 
 #if ( __GLASGOW_HASKELL__ >= 800 )
@@ -37,8 +41,13 @@ import           GHC.Float            (Double (..), Float (..), Floating (..), s
 import           GHC.Num              (Integer, Num (..), subtract)
 import           GHC.Real             hiding ((%))
 import           GHC.Show             (Show (..))
+#if MIN_VERSION_base(4,10,0)
+import           GHC.TypeNats         (CmpNat, KnownNat, Nat, SomeNat (..), natVal,
+                                       someNatVal)
+#else
 import           GHC.TypeLits         (CmpNat, KnownNat, Nat, SomeNat (..), natVal,
                                        someNatVal)
+#endif
 
 import           GHC.Types            (Bool, Char, Coercible, IO, Int, Ordering, Word)
 


### PR DESCRIPTION
This resolves #65.

You can exercise this by building against resolver=nightly. Current LTS is still on base-4.9.0.0