### PR TITLE
[#124] Reexport more for Exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   Reexport `hashWithSalt` from `Data.Hashable`.
 * [#95](https://github.com/serokell/universum/issues/95):
   Reexport `Compose` from `Data.Functor.Compose`.
+* [#124](https://github.com/serokell/universum/issues/124):
+  Export methods of class `Exception`.
 
 1.0.3
 =====

--- a/src/Universum/Exception.hs
+++ b/src/Universum/Exception.hs
@@ -15,7 +15,7 @@ module Universum.Exception
        ) where
 
 -- exceptions from safe-exceptions
-import Control.Exception.Safe (Exception, MonadCatch, MonadMask (..), MonadThrow,
+import Control.Exception.Safe (Exception (..), MonadCatch, MonadMask (..), MonadThrow,
                                SomeException (..), bracket, bracketOnError, bracket_, catch,
                                catchAny, displayException, finally, handleAny, mask_, onException,
                                throwM, try, tryAny)

--- a/universum.cabal
+++ b/universum.cabal
@@ -72,7 +72,7 @@ library
                      , bytestring
                      , containers
                      , deepseq
-                     , ghc-prim
+                     , ghc-prim >= 0.4.0.0
                      , hashable
                      , microlens
                      , microlens-mtl


### PR DESCRIPTION
Resolves #124 

Also specifies explicit lower bound for `ghc-prim` to keep backwards compatibility.