### PR TITLE
[#113] Start of liquid haskell and universum story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ TAGS
 
 .dir-locals.el
 *.html
+
+*.liquid

--- a/src/Universum/Nub.hs
+++ b/src/Universum/Nub.hs
@@ -32,9 +32,25 @@ import Data.Eq (Eq)
 import Data.Hashable (Hashable)
 import Data.HashSet as HashSet
 import Data.Ord (Ord)
-import Prelude ((.))
+import Data.Set (Set)
+import Prelude (Bool, Char, (.))
 
 import qualified Data.Set as Set
+
+-- Liquid Haskell check for duplicates.
+{-@ type ListUnique a = {v : [a] | NoDups v} @-}
+
+{-@ predicate NoDups L = Set_emp (dups L) @-}
+
+{-@ measure dups :: [a] -> (Set a)
+    dups ([])   = {v | Set_emp v}
+    dups (x:xs) = {v | v =
+      if (Set_mem x (listElts xs))
+      then (Set_cup (Set_sng x) (dups xs))
+      else (dups xs)}
+@-}
+
+{-@ Set.toList :: s : Set a -> ListUnique a @-}
 
 -- | Like 'Prelude.nub' but runs in @O(n * log n)@ time and requires 'Ord'.
 --
@@ -66,6 +82,7 @@ hashNub = go HashSet.empty
 --
 -- >>> sortNub [3, 3, 3, 2, 2, -1, 1]
 -- [-1,1,2,3]
+{-@ sortNub :: [a] -> ListUnique a @-}
 sortNub :: (Ord a) => [a] -> [a]
 sortNub = Set.toList . Set.fromList
 

--- a/src/Universum/Unsafe.hs
+++ b/src/Universum/Unsafe.hs
@@ -30,6 +30,10 @@ import Data.Maybe (fromJust)
 import Universum.Base (Int)
 import Universum.Function (flip)
 
+-- Non empty list definition for @liquidhaskell@.
+{-@ type NonEmptyList a = {xs:[a] | len xs > 0} @-}
+
 -- | Similar to '!!' but with flipped arguments.
+{-@ at :: n : Nat -> {xs : NonEmptyList a | len xs > n} -> a @-}
 at :: Int -> [a] -> a
-at = flip (!!)
+at n xs = xs !! n


### PR DESCRIPTION
Well, I have put a lot of effort in this tiny number of code lines. Trust me it wasn't that easy (at least for me).

You can noticed that `at` function doesn't use eta-reduction anymore, this is because some not clear problem. I opened the issue https://github.com/ucsd-progsys/liquidhaskell/issues/1255 . Let's see what they say.

Also the plan was to make `Nub` module covered by the property checks, but I don't know how to make the duplication check work with apparently not so trivial logic for `liquidhaskell` for such functions like `ordNub`. And the other thing is I noticed that there is no `Set_emp`-like functions for `HashSet` so either we should write all of them like for `Set`[(see here)](https://github.com/ucsd-progsys/liquidhaskell/blob/fc1c5fbd2faede27d6e21c59a40f6bd8a5b8ce2f/include/Data/Set.spec) or I don't know. Though it still doesn't help with duplication check for non trivial `hashNub`. 