### PR TITLE
Replace text-format with formatting package

### DIFF
--- a/src/Universum/String/Conversion.hs
+++ b/src/Universum/String/Conversion.hs
@@ -32,7 +32,7 @@ import Data.Bifunctor (first)
 import Data.Either (Either)
 import Data.Function (id, (.))
 import Data.String (String)
-import Data.Text.Buildable (build)
+import Formatting.Buildable (build)
 import Data.Text.Lazy.Builder (toLazyText)
 
 import Universum.Functor ((<$>))

--- a/src/Universum/String/Reexport.hs
+++ b/src/Universum/String/Reexport.hs
@@ -15,13 +15,13 @@ module Universum.String.Reexport
        , module Data.ByteString
 
          -- * Buildable
-       , module Data.Text.Buildable
+       , module Formatting.Buildable
        ) where
 
 import Data.ByteString (ByteString)
 import Data.String (IsString (..))
 import Data.Text (Text, lines, unlines, unwords, words)
-import Data.Text.Buildable (Buildable)
+import Formatting.Buildable (Buildable)
 import Data.Text.Encoding (decodeUtf8', decodeUtf8With)
 import Data.Text.Encoding.Error (OnDecodeError, OnError, UnicodeException, lenientDecode,
                                  strictDecode)

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -1,6 +1,7 @@
 resolver: lts-6.24
 
 extra-deps:
+- formatting-6.3.1
 - hedgehog-0.5.2
 - tasty-hedgehog-0.1.0.2
 - type-operators-0.1.0.4

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -4,4 +4,5 @@ nix:
   packages: [binutils, gmp]
 
 extra-deps:
+- formatting-6.3.1
 - tasty-hedgehog-0.1.0.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,6 @@ resolver: lts-10.7
 
 nix:
   shell-file: shell.nix
+
+extra-deps:
+- formatting-6.3.1

--- a/universum.cabal
+++ b/universum.cabal
@@ -73,6 +73,7 @@ library
                      , bytestring
                      , containers
                      , deepseq
+                     , formatting
                      , ghc-prim >= 0.4.0.0
                      , hashable
                      , microlens
@@ -81,7 +82,6 @@ library
                      , safe-exceptions
                      , stm
                      , text
-                     , text-format
                      , transformers
                      , type-operators
                      , unordered-containers


### PR DESCRIPTION
Use the maintained `formatting` package as a replacement for `text-format` (The `Data.Text.Buildable` module has [been folded into `formatting`](https://github.com/chrisdone/formatting/pull/33))

Resolves #157 