### PR TITLE
Added hPutStr and hPutStrLn to the Print module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,17 @@ Unreleased
 * [#204](https://github.com/serokell/universum/issues/186):
   Make `trace` non-polymorphic over text argument, add `traceIdWith` and `traceShowIdWith`.
 
+* [#197](https://github.com/serokell/universum/pull/197) `hPutStr`, `hPutStrLn`
+  and `hPrint` added to `Universum.Print`. The interface for the backing
+  typeclass `Universum.Print.Print` changed. It was also moved to the internal
+  module `Universum.Print.Internal` and should be considered unstable.
+
+  _Migration guide:_ The interface for the `Print` class should be considered
+  internal and may be subject to sudden change. If you **must** implement your
+  own instances, then import `Universum.Print.Internal` (be aware that there are
+  name clashes in the functions from `Universum.Print` and
+  `Universum.Print.Internal`)
+
 1.4.0
 =====
 

--- a/src/Universum/Print.hs
+++ b/src/Universum/Print.hs
@@ -7,6 +7,8 @@
 
 module Universum.Print
        ( Print (..)
+       , putStr
+       , putStrLn
        , print
        , putText
        , putTextLn
@@ -18,7 +20,8 @@ import Data.Function ((.))
 
 import Universum.Monad.Reexport (MonadIO, liftIO)
 
-import qualified Prelude (print, putStr, putStrLn)
+import qualified Prelude (print)
+import qualified System.IO as SIO (hPutStr, hPutStrLn, Handle)
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
@@ -33,28 +36,35 @@ import qualified Universum.Base as Base
 
 -- | Polymorfic over string and lifted to 'MonadIO' printing functions.
 class Print a where
-  putStr :: MonadIO m => a -> m ()
-  putStrLn :: MonadIO m => a -> m ()
+  hPutStr :: MonadIO m => SIO.Handle -> a -> m ()
+  hPutStrLn :: MonadIO m => SIO.Handle -> a -> m ()
 
 instance Print T.Text where
-  putStr = liftIO . T.putStr
-  putStrLn = liftIO . T.putStrLn
+  hPutStr h = liftIO . T.hPutStr h
+  hPutStrLn h = liftIO . T.hPutStrLn h
 
 instance Print TL.Text where
-  putStr = liftIO . TL.putStr
-  putStrLn = liftIO . TL.putStrLn
+  hPutStr h = liftIO . TL.hPutStr h
+  hPutStrLn h = liftIO . TL.hPutStrLn h
 
 instance Print BS.ByteString where
-  putStr = liftIO . BS.putStr
-  putStrLn = liftIO . BS.putStrLn
+  hPutStr h = liftIO . BS.hPutStr h
+  hPutStrLn h = liftIO . BS.hPutStrLn h
 
 instance Print BL.ByteString where
-  putStr = liftIO . BL.putStr
-  putStrLn = liftIO . BL.putStrLn
+  hPutStr h = liftIO . BL.hPutStr h
+  hPutStrLn h = liftIO . BL.hPutStrLn h
 
 instance Print [Base.Char] where
-  putStr = liftIO . Prelude.putStr
-  putStrLn = liftIO . Prelude.putStrLn
+  hPutStr h = liftIO . SIO.hPutStr h
+  hPutStrLn h = liftIO . SIO.hPutStrLn h
+
+
+putStr :: (Print a, MonadIO m) => a -> m ()
+putStr = hPutStr Base.stdout
+
+putStrLn :: (Print a, MonadIO m) => a -> m ()
+putStrLn = hPutStrLn Base.stdout
 
 -- | Lifted version of 'Prelude.print'.
 print :: forall a m . (MonadIO m, Base.Show a) => a -> m ()

--- a/src/Universum/Print.hs
+++ b/src/Universum/Print.hs
@@ -36,6 +36,7 @@ module Universum.Print
        -- ** Writing strings to an arbitrary 'Handle'
        , hPutStr
        , hPutStrLn
+       , hPrint
        ) where
 
 import Data.Function ((.))
@@ -46,7 +47,7 @@ import Universum.Print.Internal (Print)
 import qualified Universum.Print.Internal as I (hPutStrLn, hPutStr)
 
 import qualified Prelude (print)
-import qualified System.IO as SIO (Handle)
+import qualified System.IO as SIO (Handle, hPrint)
 
 import qualified Data.Text as T
 
@@ -79,6 +80,11 @@ putStrLn = hPutStrLn Base.stdout
 print :: forall a m . (MonadIO m, Base.Show a) => a -> m ()
 print = liftIO . Prelude.print
 {-# SPECIALIZE print :: Base.Show a => a -> Base.IO () #-}
+
+-- | Lifted version of 'System.IO.hPrint'
+hPrint :: (MonadIO m, Base.Show a) => SIO.Handle -> a -> m ()
+hPrint h = liftIO . SIO.hPrint h
+{-# SPECIALIZE hPrint :: Base.Show a => SIO.Handle -> a -> Base.IO () #-}
 
 -- | Specialized to 'T.Text' version of 'putStr' or forcing type inference.
 putText :: MonadIO m => T.Text -> m ()

--- a/src/Universum/Print/Internal.hs
+++ b/src/Universum/Print/Internal.hs
@@ -1,0 +1,53 @@
+{-|
+Module      : $header$
+Description : Class machinery for overloaded writing of String-like types
+Copyright   : (c) Justus Adam 2018
+License     : MIT
+Maintainer  : Serokell <hi@serokell.io>
+Stability   : experimental
+Portability : portable
+
+You may import this module to define your own, custom instances of 'Print'. Be
+advised however that this module is an internal API and may be subject to change
+__even for minor version increments__.
+-}
+{-# LANGUAGE FlexibleInstances #-}
+module Universum.Print.Internal (Print(..)) where
+
+import qualified System.IO as SIO (hPutStr, hPutStrLn, Handle)
+
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.IO as TL
+
+import qualified Universum.Base as Base
+
+-- | Support class to overload writing of string like values.
+class Print a where
+  hPutStr :: SIO.Handle -> a -> Base.IO ()
+  hPutStrLn :: SIO.Handle -> a -> Base.IO ()
+
+instance Print T.Text where
+  hPutStr = T.hPutStr
+  hPutStrLn = T.hPutStrLn
+
+instance Print TL.Text where
+  hPutStr = TL.hPutStr
+  hPutStrLn = TL.hPutStrLn
+
+instance Print BS.ByteString where
+  hPutStr = BS.hPutStr
+  hPutStrLn = BS.hPutStrLn
+
+instance Print BL.ByteString where
+  hPutStr = BL.hPutStr
+  hPutStrLn = BL.hPutStrLn
+
+instance Print [Base.Char] where
+  hPutStr = SIO.hPutStr
+  hPutStrLn = SIO.hPutStrLn

--- a/universum.cabal
+++ b/universum.cabal
@@ -61,6 +61,7 @@ library
                            Universum.Monoid
                            Universum.Nub
                            Universum.Print
+                               Universum.Print.Internal
                            Universum.String
                                Universum.String.Conversion
                                Universum.String.Reexport


### PR DESCRIPTION
## Problem

I was rather surprised to find that Universum does not export a version of `hPutStrLn` and `hPutStr` etc.

## Solution

This PR adds both `hPutStr` as well as `hPutStrLn` to `Universum.Print`. 
`putStr` as well as `putStrLn` are still available and exported from `Universum.Print`.

## Implementation considerations

I decided, in the spirit of a smaller surface area and code of `Universum.Print`, to completely switch the `Print` class methods.

My logic was that this is a class people rarely implement themselves. (It may perhaps even be prudent not to export `hPutStrLn` and `hPutStr` as methods but as normal functions instead).

I am open for comments and improvement suggestions though.

## Alternatives

### Additional `HPrint` typeclass

```hs
class HPrint a where
    hPutStrLn :: MonadIO m => Handle -> a -> m ()
    hPutStr :: MonadIO m => Handle -> a -> m ()

class Print a where
    putStr :: MonadIO m => a -> m ()
    default putStr :: (MonadIO m, HPrint a) => a -> m ()
    putStr = hPutStr stdout
    putStrLn :: MonadIO m => a -> m ()
    default putStrLn :: (MonadIO m, HPrint a) => a -> m ()
    putStrLn = hPutStrLn stdout 
```

An extra type class that encodes printing to handles.
This avoids the problem of possibly breaking backwards compatibility by changing the signature and names of methods in `Print` but means more code and a larger surface area for the module.

The methods for `Print` may also have default signatures that utilize `HPrint`
