### PR TITLE
[#186] Implemented hClose and withFile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Unreleased
+=====
+
+* [#200](https://github.com/serokell/universum/pull/200):
+  Implemented a lifted version of `withFile` and added `hClose` to
+  `Universum.Lifted.File` as discussed previously in
+  [#186](https://github.com/serokell/universum/issues/186).
+
 1.4.0
 =====
 
@@ -37,7 +45,7 @@
   _Migration guide:_ use `Universum.id` instead.
 * [#170](https://github.com/serokell/universum/pull/170):
   Remove `ElementConstraint` from the `Container` class.
-  
+
   _Migration guide:_ remove `ElementConstraint` from every instance and every type signature.
 * [#174](https://github.com/serokell/universum/issues/174)
   The `type-operators` dependency has been removed.
@@ -59,7 +67,7 @@
 * [#180](https://github.com/serokell/universum/issues/180):
   The `Lifted.ST` module has been deprecated. To be removed in a future
   version.
-  
+
   _Migration guide:_ use `liftIO` directly with functions from
   `Control.Monad.ST` instead.
 * [#181](https://github.com/serokell/universum/issues/181):

--- a/src/Universum/Base.hs
+++ b/src/Universum/Base.hs
@@ -63,7 +63,7 @@ import Data.Word (Word, Word16, Word32, Word64, Word8, byteSwap16, byteSwap32, b
 import Numeric.Natural (Natural)
 
 -- IO
-import System.IO (FilePath, Handle, IOMode (..), stderr, stdin, stdout, withFile)
+import System.IO (FilePath, Handle, IOMode (..), stderr, stdin, stdout)
 
 -- Base typeclasses
 import Data.Eq (Eq (..))

--- a/src/Universum/Lifted/File.hs
+++ b/src/Universum/Lifted/File.hs
@@ -22,7 +22,7 @@ import Prelude (FilePath)
 import System.IO (Handle, IOMode)
 
 import qualified Data.Text.IO as XIO
-import qualified System.IO as XIO (openFile, hClose)
+import qualified System.IO as XIO (openFile, hClose, IO)
 
 ----------------------------------------------------------------------------
 -- Text
@@ -63,4 +63,10 @@ hClose = liftIO . XIO.hClose
 withFile :: (MonadIO m, MonadMask m) => FilePath -> IOMode -> (Handle -> m a) -> m a
 withFile filePath mode f = bracket (openFile filePath mode) hClose f
 
--- 'withFile' can't be lifted into 'MonadIO', as it uses 'bracket'
+{-# SPECIALIZE appendFile :: FilePath -> Text -> XIO.IO () #-}
+{-# SPECIALIZE getLine :: XIO.IO Text #-}
+{-# SPECIALIZE readFile :: FilePath -> XIO.IO Text #-}
+{-# SPECIALIZE writeFile :: FilePath -> Text -> XIO.IO () #-}
+{-# SPECIALIZE openFile :: FilePath -> IOMode -> XIO.IO Handle #-}
+{-# SPECIALIZE hClose :: Handle -> XIO.IO () #-}
+{-# SPECIALIZE withFile :: FilePath -> IOMode -> (Handle -> XIO.IO a) -> XIO.IO a #-}

--- a/src/Universum/Lifted/File.hs
+++ b/src/Universum/Lifted/File.hs
@@ -49,17 +49,30 @@ writeFile a b = liftIO (XIO.writeFile a b)
 {-# INLINE writeFile #-}
 
 -- | Lifted version of 'System.IO.openFile'.
+--
+-- See also 'withFile' for more information.
 openFile :: MonadIO m => FilePath -> IOMode -> m Handle
 openFile a b = liftIO (XIO.openFile a b)
 {-# INLINE openFile #-}
 
 -- | Close a file handle
+--
+-- See also 'withFile' for more information.
 hClose :: MonadIO m => Handle -> m ()
 hClose = liftIO . XIO.hClose
 {-# INLINE hClose #-}
 
--- | 'bracket' specialized to files. This should be preferred over 'openFile' +
--- 'hClose' as it properly deals with (asynchronous) exceptions.
+-- | Opens a file, manipulates it with the provided function and closes the
+-- handle before returning. The 'Handle' can be written to using the
+-- 'Universum.Print.hPutStr' and 'Universum.Print.hPutStrLn' functions.
+--
+-- 'withFile' is essentially the 'bracket' pattern, specialized to files. This
+-- should be preferred over 'openFile' + 'hClose' as it properly deals with
+-- (asynchronous) exceptions. In cases where 'withFile' is insufficient, for
+-- instance because the it is not statically known when manipulating the
+-- 'Handle' has finished, one should consider other safe paradigms for resource
+-- usage, such as the @ResourceT@ transformer from the @resourcet@ package,
+-- before resorting to 'openFile' and 'hClose'.
 withFile :: (MonadIO m, MonadMask m) => FilePath -> IOMode -> (Handle -> m a) -> m a
 withFile filePath mode f = bracket (openFile filePath mode) hClose f
 


### PR DESCRIPTION
So I read the heading of #186 and thought "hey, they should have `withFile`". Only after I started to implement it did I realize that discussion was already happening.

So I sort of accidentally already did the implementation.

This version currently exports `withFile` **and** `openFile` and `hClose`. And simply advises against using `openFile` and `hClose` in the documentation. Once we've settled the discussion of what should be exported this can be adjusted as needed.