### PR TITLE
Generalize the type of `die`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ Unreleased
   name clashes in the functions from `Universum.Print` and
   `Universum.Print.Internal`)
 
+* [#201](https://github.com/serokell/universum/pull/201) Generalized the type of
+  `Universum.Lifted.Env.die`. Should not break existing code, apart from,
+  perhaps, type inference.
+
 1.4.0
 =====
 

--- a/src/Universum/Lifted/Env.hs
+++ b/src/Universum/Lifted/Env.hs
@@ -36,6 +36,6 @@ exitSuccess = liftIO XIO.exitSuccess
 -- | Lifted version of 'System.Exit.die'.
 -- 'XIO.die' is available since base-4.8, but it's more convenient to
 -- redefine it instead of using CPP.
-die :: MonadIO m => String -> m ()
+die :: MonadIO m => String -> m a
 die err = liftIO (System.IO.hPutStrLn stderr err) >> exitFailure
 {-# INLINE die #-}


### PR DESCRIPTION
For some reason your lifted version of `die` is `m ()`, when it could be `m a`.

I skimmed through the issues and `CHANGES.md` but I could not find a reference as to why this was done, so I'm proposing to change it to a more general type. This is also the same type signature as the `exitWith` family as wenn as the `die` version in `base`.

Furthermore this, more general type signature is actually useful, particularly when handling erroneous user data.