### PR TITLE
Make `error` print callstack of its call site rather than its definition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 =====
 
+* Make `error`'s stacktrace exclude site of the `error` function itself.
+
 * [#200](https://github.com/serokell/universum/pull/200):
   Implemented a lifted version of `withFile` and added `hClose` to
   `Universum.Lifted.File` as discussed previously in

--- a/src/Universum/Debug.hs
+++ b/src/Universum/Debug.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE ImplicitParams     #-}
 {-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE MagicHash          #-}
 {-# LANGUAGE PolyKinds          #-}
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE Trustworthy        #-}
@@ -35,9 +37,10 @@ import GHC.Generics (Generic)
 import System.IO.Unsafe (unsafePerformIO)
 
 #if ( __GLASGOW_HASKELL__ >= 800 )
-import GHC.Exts (RuntimeRep, TYPE)
+import GHC.Exception (errorCallWithCallStackException)
+import GHC.Exts (RuntimeRep, TYPE, raise#)
 
-import Universum.Base (HasCallStack)
+import Universum.Base (HasCallStack, callStack)
 #endif
 
 import Universum.Applicative (pass)
@@ -56,10 +59,11 @@ trace string expr = unsafePerformIO (do
 #if ( __GLASGOW_HASKELL__ >= 800 )
 error :: forall (r :: RuntimeRep) . forall (a :: TYPE r) . HasCallStack
       => Text -> a
+error s = raise# (errorCallWithCallStackException (unpack s) callStack)
 #else
 error :: Text -> a
-#endif
 error s = P.error (unpack s)
+#endif
 
 -- | Version of 'Debug.Trace.traceShow' that leaves a warning.
 {-# WARNING traceShow "'traceShow' remains in code" #-}


### PR DESCRIPTION
## Description

As we know, our `error` is funny:

```
*** Exception: 123
CallStack (from HasCallStack):
  error, called at /home/martoon/serokell/universum/src/Universum/Debug.hs:62:11 in main:Universum.Debug
  error, called at <interactive>:1:1 in interactive:Ghci1
```

I hope I fixed it to work as expected:

* Called from ghci:
```
λ> error "123"
*** Exception: 123
CallStack (from HasCallStack):
  error, called at <interactive>:2:1 in interactive:Ghci1
```

* Called from code:
```
λ> meme
*** Exception: What meme?
CallStack (from HasCallStack):
  error, called at /home/martoon/serokell/universum/src/Universum/Debug.hs:109:7 in main:Universum.Debug
```

## Related issues(s)

No corresponding issue exist.

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
