### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Universum
 1. **Excellent documentation**: tutorial, migration guide from `Prelude`,
    Haddock with examples for (almost) every function,
    all examples are tested with [`doctest`](http://hackage.haskell.org/package/doctest),
-   documenation regarding internal module structure.
+   documentation regarding internal module structure.
 2. `universum`-specific [HLint](http://hackage.haskell.org/package/hlint) rules:
    [`.hlint.yaml`](https://github.com/serokell/universum/blob/master/.hlint.yaml)
 3. Only a few LiquidHaskell properties right now, but LiquidHaskell is on Travis


### PR DESCRIPTION
Randomly noticed a typo in the README (`documentation`).

## Description

Correction for a randomly noticed typo in the README (`documentation`).

## Related issues(s)

No issue link.

Fixed by adding a `t`.

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
