### PR TITLE
Add rewrite rules for text conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ Unreleased
 * [#214](https://github.com/serokell/universum/issues/214):
   Update supported GHC versions (replace 7.10.3 with 8.6.5).
 
+* [#212](https://github.com/serokell/universum/issues/212)
+  Added rewrite rule for `toString . toText` case.
+  This may change semantics in some corner cases
+  (because `toString . toText` is not strictly the identity function).
+
 1.5.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Gotchas [↑](#structure-of-this-tutorial)
 * As a consequence of previous point, some functions like `traverse_`, `forM_`, `sequenceA_`, etc.
   are generalized over `Container` type classes.
 * `error` takes `Text`.
+* We are exporting a rewrite rule which replaces `toString . toText :: Text -> Text` with `id`. Note that this changes semantics in some corner cases.
 
 
 Things that you were already using, but now you don't have to import them explicitly [↑](#structure-of-this-tutorial)

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -24,6 +24,7 @@ main = defaultMain
   , bgroupConcatMap
   , bgroupMember
   , bgroupFold
+  , bgroupTextConversion
   ]
 
 bgroupList :: forall a .
@@ -171,3 +172,11 @@ bgroupFold = do
     bgroup "foldl'" [ bench "flipped" $ nf flipFoldl' testList
                     , bench "base"    $ nf ghcFoldl'  testList
                     ]
+
+bgroupTextConversion :: Benchmark
+bgroupTextConversion =
+  let str = replicate 100000 'a'
+  in bench "toText/toString" $ whnf (countLength . toText) str
+  where
+    countLength :: Text -> Int
+    countLength x = length (toString x)

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import Universum hiding (show)
 
 import Data.List (nub, zip5)
+import qualified Data.Text as T
 import Gauge (Benchmark, bench, bgroup, nf, whnf)
 import Gauge.Main (defaultMain)
 import Prelude (show)
@@ -175,8 +176,12 @@ bgroupFold = do
 
 bgroupTextConversion :: Benchmark
 bgroupTextConversion =
-  let str = replicate 100000 'a'
-  in bench "toText/toString" $ whnf (countLength . toText) str
-  where
-    countLength :: Text -> Int
-    countLength x = length (toString x)
+  bgroup "text conversions"
+    [ let str = replicate 100000 'a'
+          countLength x = length (toString x)
+      in bench "toString . toText" $ whnf (countLength . toText) str
+
+    , let txt = T.replicate 100000 (T.singleton 'a')
+          countLength x = length (toText x)
+      in bench "toText . toString" $ whnf (countLength . toString) txt
+    ]

--- a/src/Universum/String/Conversion.hs
+++ b/src/Universum/String/Conversion.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
+{-# OPTIONS_GHC -Wno-orphans  #-}
 
 -- | This module implements type class which allow to have conversion to and
 -- from 'Text', 'String' and 'ByteString' types (including both strict and lazy
@@ -30,6 +31,8 @@ import Data.Bifunctor (first)
 import Data.Either (Either)
 import Data.Function (id, (.))
 import Data.String (String)
+import qualified Data.Text.Internal as T
+import qualified Data.Text.Internal.Fusion.Common as TF
 
 import Universum.Functor ((<$>))
 import Universum.String.Reexport (ByteString, IsString, Read, Text, fromString)
@@ -158,6 +161,96 @@ instance ToString T.Text where
 
 instance ToString LT.Text where
     toString = LT.unpack
+
+{- [Note toString-toText-rewritting]
+
+@toString . toText@ pattern may occur quite often after inlining because
+we tend to use 'Text' rather than 'String' in function signatures, but
+there are still some libraries which use 'String's and thus make us perform
+conversions back and forth.
+
+Herewith, it's tempting to define the following rule:
+
+@
+{-# RULES T.unpack (T.pack s) = s #-}.
+@
+
+This would make as to mark 'T.unpack' and 'T.pack' as non-inlinable at the
+first phases of simplifier pass because if they get inlined then obviously
+our rule cannot be applied.
+We can go this way, but we can do even better if take rules defined in
+'Data.Text' into account.
+
+Quoting investigation of @int-index:
+
+If we look at @unpack@ and @pack@ they are defined as
+
+@
+unpack = S.unstreamList . stream
+{-# INLINE [1] unpack #-}
+
+pack = unstream . S.map safe . S.streamList
+{-# INLINE [1] pack #-}
+@
+
+After they get inlined, the rule seems to be
+
+@
+(S.unstreamList . stream) ((unstream . S.map safe . S.streamList) a)
+@
+
+If we also inline function composition, we get
+
+@
+S.unstreamList (stream (unstream (S.map safe (S.streamList a))))
+@
+
+`stream` and `unstream` surely cancel out via this rule:
+
+@
+{-# RULES "STREAM stream/unstream fusion" forall s. stream (unstream s) = s #-}
+@
+
+So we are left with
+
+@
+S.unstreamList (S.map safe (S.streamList a))
+@
+
+Now, what's this 'safe' function? Turns out it's defined as
+
+@
+safe :: Char -> Char
+safe c
+    | ord c .&. 0x1ff800 /= 0xd800 = c
+    | otherwise                    = '\xfffd'
+@
+
+Aha, so it's mapping some codepoints to @'\xfffd'@!
+There's a comment on top of it to explain this:
+
+```
+-- UTF-16 surrogate code points are not included in the set of Unicode
+-- scalar values, but are unfortunately admitted as valid 'Char'
+-- values by Haskell.  They cannot be represented in a 'Text'.  This
+-- function remaps those code points to the Unicode replacement
+-- character (U+FFFD, \'&#xfffd;\'), and leaves other code points
+-- unchanged.
+```
+
+This logic is lost with the mentioned rewrite rule.
+Not a huge loss, but it does mean that this rewrite rule isn't meaning preserving.
+
+
+We hope that in most cases it's fine.
+And if it's not, one can mark his function using either @pack@ or @unpack@
+with @NOINLINE@ pragma to prevent the rule from firing.
+
+So eventually we end up with the following rule:
+-}
+{-# RULES "pack/unpack" [1]
+    forall s. TF.unstreamList (TF.map T.safe (TF.streamList s)) = s
+#-}
 
 -- | Polymorhpic version of 'Text.Read.readEither'.
 --

--- a/src/Universum/String/Conversion.hs
+++ b/src/Universum/String/Conversion.hs
@@ -254,8 +254,21 @@ So, eventually, we add the following rule:
 
 {- In case if GHC didn't manage to inline and rewrite everything in
 the remaining phases (@Data.Text.pack@ is inlined at 1-st phase),
-we still have this rule. Hopefully, one of them will fire.
+we still have "pack/unpack" rule. Hopefully, one of them will fire.
 -}
+
+{- The opposite rule is safe to have because 'T.safe' /is/ the identity
+function for strings made up from valid characters, and text is guaranteed
+to have only valid ones.
+However, for this case there is no @unstream (stream s) = id@ rule,
+so we don't delve deep into internals. As long as @stream@ and @unstream@
+only perform conversion between text and stream of characters, they should
+be safe to collapse.
+-}
+{-# RULES "unpack/pack" [~0]
+    forall s. T.pack (T.unpack s) = s
+#-}
+
 -- | Polymorhpic version of 'Text.Read.readEither'.
 --
 -- >>> readEither @Text @Int "123"

--- a/test/Test/Universum/Property.hs
+++ b/test/Test/Universum/Property.hs
@@ -31,6 +31,7 @@ stringProps = testGroup "String conversions"
     [ testProperty "toString . toText = id" prop_StringToTextAndBack
     , testProperty "`toString . toText` for UTF-16 surrogate"
         prop_StringToTextAndBackSurrogate
+    , testProperty "toText . toString = id" prop_TextToStringAndBack
     ]
 
 utfProps :: TestTree
@@ -59,6 +60,9 @@ unicodeAllString = Gen.string (Range.linear 0 10000) Gen.unicodeAll
 
 utf8Text :: Gen T.Text
 utf8Text = Gen.text (Range.linear 0 10000) unicode'
+
+unicodeAllText :: Gen T.Text
+unicodeAllText = Gen.text (Range.linear 0 10000) Gen.unicodeAll
 
 utf8Bytes :: Gen B.ByteString
 utf8Bytes = Gen.utf8 (Range.linear 0 10000) unicode'
@@ -89,6 +93,11 @@ prop_StringToTextAndBackSurrogate = property $ do
   -- Without rewrite rule this string would be transformed to "\9435"
   let str = "\xD800"
   toString (toText str) === str
+
+prop_TextToStringAndBack :: Property
+prop_TextToStringAndBack = property $ do
+  txt <- forAll unicodeAllText
+  toText (toString txt) === txt
 
 prop_StringToBytes :: Property
 prop_StringToBytes = property $ do

--- a/universum.cabal
+++ b/universum.cabal
@@ -82,7 +82,9 @@ library
                      , mtl
                      , safe-exceptions
                      , stm
-                     , text
+                     -- Make sure that "toString-toText-rewritting" note
+                     -- is still valid when bumping this constraint.
+                     , text >= 1.0.0.0 && <= 1.2.3.1
                      , transformers
                      , unordered-containers
                      , utf8-string

--- a/universum.cabal
+++ b/universum.cabal
@@ -135,6 +135,7 @@ benchmark universum-benchmark
                      , universum
                      , containers
                      , gauge
+                     , text
                      , unordered-containers
 
   default-extensions:  NoImplicitPrelude


### PR DESCRIPTION
Added rewrite rule to eliminate `toString . toText` conversions.

Benchmarks without rewrite rule:

```
benchmarked toText/toString
time                 1.013 ms   (875.1 μs .. 1.148 ms)
                     0.819 R²   (0.691 R² .. 0.904 R²)
mean                 1.621 ms   (1.268 ms .. 2.619 ms)
std dev              2.134 ms   (331.2 μs .. 4.071 ms)
variance introduced by outliers: 97% (severely inflated)
```

And with rewrite rule:

```
benchmarked toText/toString
time                 186.1 μs   (183.3 μs .. 188.4 μs)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 189.4 μs   (187.7 μs .. 191.8 μs)
std dev              7.508 μs   (5.823 μs .. 10.36 μs)
variance introduced by outliers: 20% (moderately inflated)
```

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

Fixed #212.



## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
