### PR TITLE
Fix documentation in Universum.Lifted.File to mention correct module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ Unreleased
   This may change semantics in some corner cases
   (because `toString . toText` is not strictly the identity function).
 
+* [#215](https://github.com/serokell/universum/pull/215):
+  Fix docstrings in `Universum.Lifted.File` to mention correct module when
+  referencing related functions.
+
 1.5.0
 =====
 

--- a/src/Universum/Lifted/File.hs
+++ b/src/Universum/Lifted/File.hs
@@ -28,22 +28,22 @@ import qualified System.IO as XIO (openFile, hClose, IO)
 -- Text
 ----------------------------------------------------------------------------
 
--- | Lifted version of 'Data.Text.appendFile'.
+-- | Lifted version of 'Data.Text.IO.appendFile'.
 appendFile :: MonadIO m => FilePath -> Text -> m ()
 appendFile a b = liftIO (XIO.appendFile a b)
 {-# INLINE appendFile #-}
 
--- | Lifted version of 'Data.Text.getLine'.
+-- | Lifted version of 'Data.Text.IO.getLine'.
 getLine :: MonadIO m => m Text
 getLine = liftIO XIO.getLine
 {-# INLINE getLine #-}
 
--- | Lifted version of 'Data.Text.readFile'.
+-- | Lifted version of 'Data.Text.IO.readFile'.
 readFile :: MonadIO m => FilePath -> m Text
 readFile a = liftIO (XIO.readFile a)
 {-# INLINE readFile #-}
 
--- | Lifted version of 'Data.Text.writeFile'.
+-- | Lifted version of 'Data.Text.IO.writeFile'.
 writeFile :: MonadIO m => FilePath -> Text -> m ()
 writeFile a b = liftIO (XIO.writeFile a b)
 {-# INLINE writeFile #-}


### PR DESCRIPTION
# Description

There is a typo in referenced module names - there is no file related functions in `Data.Text` (correct module is `Data.Text.IO`). This PR fixes the issue. 

Issue could be observed here http://hackage.haskell.org/package/universum-1.5.0/docs/Universum-Lifted-File.html

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

