### PR TITLE
[#219] Support recent nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,10 @@ matrix:
     env: GHCVER='8.4.3' STACK_YAML="$HOME/build/serokell/universum/stack-$GHCVER.yaml"
 
   - ghc: 8.6.5
-    env: GHCVER='8.4.3' STACK_YAML="$HOME/build/serokell/universum/stack.yaml"
+    env: GHCVER='8.6.5' STACK_YAML="$HOME/build/serokell/universum/stack.yaml"
+
+  - ghc: 8.8.1
+    env: GHCVER='8.8.1' STACK_YAML="$HOME/build/serokell/universum/stack-$GHCVER.yaml"
 
   - ghc: 8.2.2
     env: GHCVER='8.2.2' STACK_YAML="$HOME/build/serokell/universum/stack-liquid.yaml"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 =====
 
+1.6.1
+=====
+
 * [#219](https://github.com/serokell/universum/issues/219):
   Bump upper bound on `text`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 =====
 
+* [#219](https://github.com/serokell/universum/issues/219):
+  Bump upper bound on `text`.
+
 1.6.0
 =====
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ There is also the `type:unclear` label for issues which don't have a list of spe
 Processing of an issue depends on its category. Specifically:
 1. A `not-code` issue can be resolved at any time.
 PRs can be merged whenever GitHub allows it.
-Minimal number of approvals is set to 2 in GitHub settings.
+Minimal number of approvals is set in GitHub settings.
 2. Rules for the `fix` issues are the same as for `not-code` with an additional rule that PRs for such issues should increase the last component in the version and this version should be uploaded to Hackage as soon as the PR is merged (also new tag and release are created).
 3. Work on the `feature` issues is organized in milestones.
 Each milestone corresponds to a release which increases at least the third (`feature`) version component.

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -1,0 +1,4 @@
+resolver: nightly-2019-10-07
+
+nix:
+  shell-file: shell.nix

--- a/universum.cabal
+++ b/universum.cabal
@@ -84,7 +84,7 @@ library
                      , stm
                      -- Make sure that "toString-toText-rewritting" note
                      -- is still valid when bumping this constraint.
-                     , text >= 1.0.0.0 && <= 1.2.3.1
+                     , text >= 1.0.0.0 && <= 1.2.4.0
                      , transformers
                      , unordered-containers
                      , utf8-string

--- a/universum.cabal
+++ b/universum.cabal
@@ -1,5 +1,5 @@
 name:                universum
-version:             1.6.0
+version:             1.6.1
 synopsis:            Custom prelude used in Serokell
 description:         See README.md file for more details.
 homepage:            https://github.com/serokell/universum

--- a/universum.cabal
+++ b/universum.cabal
@@ -17,6 +17,7 @@ tested-with:         GHC == 8.0.2
                    , GHC == 8.2.2
                    , GHC == 8.4.3
                    , GHC == 8.6.5
+                   , GHC == 8.8.1
 extra-doc-files:     CHANGES.md
                    , CONTRIBUTING.md
                    , README.md


### PR DESCRIPTION
## Description

Universum is not present in Stackage nightly resolver. The reason is that we have upper bound on `text` which does not work with `text` version in nightly. So here I bump this boundary and add explicit support for GHC-8.8.1.

## Related issues(s)

Fixes #219.

## ✓ Checklist for your Pull Request

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
