### PR TITLE
[#234] Add concurrent primitives working with State

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 =====
 
+1.7.3
+=====
+
 * [#236](https://github.com/serokell/universum/issues/236):
   Add `updateMVar'` and `updateTVar'`.
 * [#244](https://github.com/serokell/universum/issues/244)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 =====
 
+* [#236](https://github.com/serokell/universum/issues/236):
+  Add `updateMVar'` and `updateTVar'`.
 * [#244](https://github.com/serokell/universum/issues/244)
   Add `ToPairs` instances for `[(k, v)]` and `NonEmpty (k, v)`.
 

--- a/universum.cabal
+++ b/universum.cabal
@@ -126,7 +126,7 @@ test-suite universum-test
                      , text
                      , hedgehog
                      , tasty
-                     , tasty-hedgehog
+                     , tasty-hedgehog < 1.2.0.0
 
   if impl(ghc >= 8.10.1)
     ghc-options:         -Wno-missing-safe-haskell-mode

--- a/universum.cabal
+++ b/universum.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                universum
-version:             1.7.2
+version:             1.7.3
 synopsis:            Custom prelude used in Serokell
 description:         See README.md file for more details.
 homepage:            https://github.com/serokell/universum


### PR DESCRIPTION
Problem: existing `modifyTVar'` is not pretty convenient. You need to
e.g. remember the order of arguments, and if several transformations
are required, composing them neatly may be difficult.

Solution: provide methods working with `State`, not a lambda. This way
one can write down modifications in do-block which is convenient.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

Fixed #234 by adding the respective methods. 

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
