### PR TITLE
Rename "note" function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 =====
 
+* [#176](https://github.com/serokell/universum/issues/176)
+  Renamed function `note` to `validateJust`.
+
 * [#244](https://github.com/serokell/universum/issues/244)
   Add `ToPairs` instances for `[(k, v)]` and `NonEmpty (k, v)`.
 

--- a/src/Universum/Exception.hs
+++ b/src/Universum/Exception.hs
@@ -12,7 +12,7 @@ module Universum.Exception
        , Bug (..)
        , bug
        , pattern Exc
-       , note
+       , validateJust
        ) where
 
 -- exceptions from safe-exceptions
@@ -47,8 +47,8 @@ bug e = Safe.impureThrow (Bug (Safe.toException e) callStack)
 -- To suppress redundant applicative constraint warning on GHC 8.0
 -- | Throws error for 'Maybe' if 'Data.Maybe.Nothing' is given.
 -- Operates over 'MonadError'.
-note :: (MonadError e m) => e -> Maybe a -> m a
-note err = maybe (throwError err) pure
+validateJust :: (MonadError e m) => e -> Maybe a -> m a
+validateJust err = maybe (throwError err) pure
 
 
 {- | Pattern synonym to easy pattern matching on exceptions. So intead of


### PR DESCRIPTION
## Description

Problem: `note` function has too general name. It's not clear from its name what it does.
Solution: Renamed `note` function  to `validateJust`.


## Related issues(s)

- Fixed #176 by renaming `note` function  to `validateJust`.


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
