### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,8 @@ PR can be merged only if the corresponding `feature` issue is in the upcoming mi
 However, 4 approvals (at least 3 from Serokell) are necessary for inclusion into a milestone.
 2 disapprovals from Serokell or 4 disapprovals in total are enough to prevent the issue from getting into a milestone.
 If an issue is about removal of something (`x`), it should be done in two steps.
-The first step is deprecation of `x` which happens in a `breaking` release.
-The second step is deprecation of `x` which happens in another `breaking` release after deprecation of `x`.
+The first step is to deprecate `x` which happens in a `breaking` release.
+The second step is to delete `x` which happens in another `breaking` release after deprecating `x`.
 There can't be more than one breaking release in less than 5 weeks.
 
 Note: approval of any PR implies that the person who approves it confirms that the PR corresponds to the issue mentioned there and the issue has a correct type.


### PR DESCRIPTION
## Description

This PR fixes a small typo in `CONTRIBUTING.MD`

> The second step is deprecation of `x`

↓

> The second step is to delete `x`

## Related issues(s)

None


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [ ] [README](/README.md)
  - [ ] Haddock

- Record your changes

  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
