### PR TITLE
[#206] Remove `listToMaybe`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Unreleased
 * [#176](https://github.com/serokell/universum/issues/176):
   Deprecate `note`.
 
+* [#206](https://github.com/serokell/universum/issues/206):
+  Remove `listToMaybe`.
+  _Migration guide:_ use `safeHead` directly with functions from
+  `Universum.Container` instead.
+
 1.7.3
 =====
 

--- a/src/Universum/Monad/Reexport.hs
+++ b/src/Universum/Monad/Reexport.hs
@@ -57,7 +57,7 @@ import Control.Monad.Trans.Identity (IdentityT (runIdentityT))
 import Control.Monad.Trans.Maybe (MaybeT (..), exceptToMaybeT, maybeToExceptT)
 
 -- Maybe
-import Data.Maybe (Maybe (..), catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe,
+import Data.Maybe (Maybe (..), catMaybes, fromMaybe, isJust, isNothing, mapMaybe,
                    maybe, maybeToList)
 
 -- Either


### PR DESCRIPTION
## Description

## Problem 
We export `listToMaybe` from `Data.Maybe`. It makes no sense
because we have `safeHead` in `Universum.Container` which does the same thing.

## Solution 
Remove `listToMaybe` from export list.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

- Fixes #206

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
