### PR TITLE
[#176] Deprecate `note`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 =====
 
+* [#176](https://github.com/serokell/universum/issues/176):
+  Deprecate `note`.
+
 1.7.3
 =====
 

--- a/src/Universum/Exception.hs
+++ b/src/Universum/Exception.hs
@@ -47,6 +47,7 @@ bug e = Safe.impureThrow (Bug (Safe.toException e) callStack)
 -- To suppress redundant applicative constraint warning on GHC 8.0
 -- | Throws error for 'Maybe' if 'Data.Maybe.Nothing' is given.
 -- Operates over 'MonadError'.
+{-# DEPRECATED note "Don't use this function. Use 'maybeToRight' instead" #-}
 note :: (MonadError e m) => e -> Maybe a -> m a
 note err = maybe (throwError err) pure
 


### PR DESCRIPTION
## Description

## Problem 
`note` function from `Universum.Exception` is useless:
- `maybeToRight` is enough for most use cases
- it's specialized to `MonadError`, but in the wild there are also `MonadFail`, `MonadThrow`, `Either`, etc.

## Solution 
Deprecate `note`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

- Fixes #176 

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
