### PR TITLE
[#182] Deprecate `microlens` and `microlens-mtl` dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ Unreleased
   _Migration guide:_ use `safeHead` directly with functions from
   `Universum.Container` instead.
 
+* [#182](https://github.com/serokell/universum/issues/182):
+  Deprecate `microlens` and `microlens-mtl` dependencies.
+
 1.7.3
 =====
 

--- a/src/Universum.hs
+++ b/src/Universum.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE RankNTypes #-}
 
 {- | Main module that reexports all functionality allowed to use
 without importing any other modules. Just add next lines to your
@@ -80,8 +81,26 @@ module Universum
        , module Universum.VarArg
 
          -- * Lenses
-       , module Lens.Micro
-       , module Lens.Micro.Mtl
+       , Lens
+       , Lens'
+       , Traversal
+       , Traversal'
+       , over
+       , set
+       , (%~)
+       , (.~)
+       , (^.)
+       , (^..)
+       , (^?)
+       , _1
+       , _2
+       , _3
+       , _4
+       , _5
+       , preuse
+       , preview
+       , use
+       , view
        ) where
 
 import Universum.Applicative
@@ -104,6 +123,95 @@ import Universum.TypeOps
 import Universum.VarArg
 
 -- Lenses
-import Lens.Micro (Lens, Lens', Traversal, Traversal', over, set, (%~), (&), (.~), (<&>), (^.),
-                   (^..), (^?), _1, _2, _3, _4, _5)
-import Lens.Micro.Mtl (preuse, preview, use, view)
+import qualified Lens.Micro (ASetter, Getting, over, set, (%~), (.~), (^.),
+                             (^..), (^?), _1, _2, _3, _4, _5)
+import qualified Lens.Micro.Mtl (preuse, preview, use, view)
+import Lens.Micro.Internal (Field1, Field2, Field3, Field4, Field5)
+
+{-# DEPRECATED
+    Lens
+  , Lens'
+  , Traversal
+  , Traversal'
+  , over
+  , set
+  , (%~)
+  , (.~)
+  , (^.)
+  , (^..)
+  , (^?)
+  , _1
+  , _2
+  , _3
+  , _4
+  , _5
+  , preuse
+  , preview
+  , use
+  , view
+  "Use corresponding function from 'lens' or 'microlens' package"
+#-}
+
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+type Lens' s a = Lens s s a a
+
+type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
+type Traversal' s a = Traversal s s a a
+
+over :: Lens.Micro.ASetter s t a b -> (a -> b) -> s -> t
+over = Lens.Micro.over
+
+set :: Lens.Micro.ASetter s t a b -> b -> s -> t
+set = Lens.Micro.set
+
+(%~) :: Lens.Micro.ASetter s t a b -> (a -> b) -> s -> t
+(%~) = (Lens.Micro.%~)
+
+infixr 4 %~
+
+(.~) :: Lens.Micro.ASetter s t a b -> b -> s -> t
+(.~) = (Lens.Micro..~)
+
+infixr 4 .~
+
+(^.) :: s -> Lens.Micro.Getting a s a -> a
+(^.) = (Lens.Micro.^.)
+
+infixl 8 ^.
+
+(^..) :: s -> Lens.Micro.Getting (Endo [a]) s a -> [a]
+(^..) = (Lens.Micro.^..)
+
+infixl 8 ^..
+
+(^?) :: s -> Lens.Micro.Getting (First a) s a -> Maybe a
+(^?) = (Lens.Micro.^?)
+
+infixl 8 ^?
+
+_1 :: Field1 s t a b => Lens s t a b
+_1 = Lens.Micro._1
+
+_2 :: Field2 s t a b => Lens s t a b
+_2 = Lens.Micro._2
+
+_3 :: Field3 s t a b => Lens s t a b
+_3 = Lens.Micro._3
+
+_4 :: Field4 s t a b => Lens s t a b
+_4 = Lens.Micro._4
+
+_5 :: Field5 s t a b => Lens s t a b
+_5 = Lens.Micro._5
+
+preuse :: MonadState s m => Lens.Micro.Getting (First a) s a -> m (Maybe a)
+preuse = Lens.Micro.Mtl.preuse
+
+preview :: MonadReader s m => Lens.Micro.Getting (First a) s a -> m (Maybe a)
+preview = Lens.Micro.Mtl.preview
+
+use :: MonadState s m => Lens.Micro.Getting a s a -> m a
+use = Lens.Micro.Mtl.use
+
+view :: MonadReader s m => Lens.Micro.Getting a s a -> m a
+view = Lens.Micro.Mtl.view

--- a/src/Universum/Function.hs
+++ b/src/Universum/Function.hs
@@ -6,4 +6,4 @@ module Universum.Function
        ( module Data.Function
        ) where
 
-import Data.Function (const, fix, flip, id, on, ($), (.))
+import Data.Function (const, fix, flip, id, on, ($), (.), (&))

--- a/src/Universum/Functor/Reexport.hs
+++ b/src/Universum/Functor/Reexport.hs
@@ -12,6 +12,6 @@ module Universum.Functor.Reexport
 
 import Control.Arrow ((&&&))
 import Data.Bifunctor (Bifunctor (..))
-import Data.Functor (Functor (..), void, ($>), (<$>))
+import Data.Functor (Functor (..), void, ($>), (<$>), (<&>))
 import Data.Functor.Compose (Compose (..))
 import Data.Functor.Identity (Identity (..))


### PR DESCRIPTION
## Description

## Problem 
Using `lens` library with `Universum` is uncomfortable
because some definitions start clashing (e.g. `Lens` or `(^.)`).

## Solution 
Deprecate these `microlens` and `microlens-mtl` dependencies.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

- Fixes part of #182

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
