### PR TITLE
[#208] `redundant constraint` test

### DIFF
--- a/test/Test/Universum/Issue208.hs
+++ b/test/Test/Universum/Issue208.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE
+    GeneralizedNewtypeDeriving
+  , UndecidableInstances
+  , FlexibleContexts
+  , GADTs
+  , DerivingStrategies
+  , CPP
+#-}
+module Test.Universum.Issue208
+  () where
+
+#if __GLASGOW_HASKELL__ >= 900
+
+import Universum (Container)
+
+-- In ghc-8.6.3 this code will produce a @redundant constraint@ warning.
+-- In ghc-9.0.2 and newer no warnings would be produced.
+-- Issue #208: https://github.com/serokell/universum/issues/208
+
+newtype Test = Test [Int]
+    deriving newtype (Container)
+
+#endif

--- a/universum.cabal
+++ b/universum.cabal
@@ -121,7 +121,9 @@ test-suite universum-test
   hs-source-dirs:      test
   main-is:             Spec.hs
 
-  other-modules:       Test.Universum.Property
+  other-modules:
+                       Test.Universum.Issue208
+                       Test.Universum.Property
 
   build-depends:       universum
                      , bytestring


### PR DESCRIPTION
## Description

## Problem 
In `ghc-8.6.3` your code can produce `redundant constraint` warning
if you derive `Container` for newtype, but in `ghc-9.0.2` and newer
no warnings would be produced.

## Solution 
Added test, that should be compiled with `ghc-9.0.2` and newer
without warnings.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

- Resolves #208

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [ ] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [ ] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
