### PR TITLE
[Chore] Fix xrefcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: serokell/xrefcheck-action@v1
       with:
-        xrefcheck-version: 0.1.2
+        xrefcheck-version: 0.2
 
   cabal:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}

--- a/.xrefcheck.yaml
+++ b/.xrefcheck.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2019-2021 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+# Parameters of repository traversal.
+traversal:
+  # Files and folders which we pretend do not exist
+  # (so they are neither analyzed nor can be referenced).
+  ignored:
+    # Git files
+    - .git
+
+    # Stack files
+    - .stack-work
+
+
+# Verification parameters.
+verification:
+  # On 'anchor not found' error, how much similar anchors should be displayed as
+  # hint. Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
+  # Prefixes of files, references in which should not be analyzed.
+  notScanned:
+    - .github/pull_request_template.md
+    - .github/issue_template.md
+    - .github/PULL_REQUEST_TEMPLATE
+    - .github/ISSUE_TEMPLATE
+
+  # Glob patterns describing the files which do not physically exist in the
+  # repository but should be treated as existing nevertheless.
+  virtualFiles:
+    - ../../../issues
+    - ../../../issues/*
+    - ../../../pulls
+    - ../../../pulls/*
+
+  # POSIX extended regular expressions that match external references
+  # that have to be ignored (not verified).
+  # It is an optional parameter, so it can be omitted.
+  ignoreRefs:
+    # Note: For some reason, running `curl -I https://opensource.org/licenses/MIT` from within
+    # a GitHub Action's agent returns a 503.
+    # For this reason, we're temporarily disabling this check.
+    - https://opensource.org/licenses/MIT
+
+# Parameters of scanners for various file types.
+scanners:
+
+  markdown:
+    # Flavor of markdown, e.g. GitHub-flavor.
+    #
+    # This affects which anchors are generated for headers.
+    flavor: GitHub


### PR DESCRIPTION
## Description

Problem: for some reason, running `curl -I
https://opensource.org/licenses/MIT` from within a GitHub Action's agent
returns a 503.

See: 
* https://github.com/serokell/universum/runs/7535914651?check_suite_focus=true
* https://github.com/serokell/universum/runs/7537865339?check_suite_focus=true

Solution: Temporarily disable this check.

## Related issues(s)

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->

None


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If your PR fixes/relates to an open issue then the description should
      reference this issue. See also [auto linking on
      github](https://help.github.com/articles/autolinked-references-and-urls/).

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
