### PR TITLE
[#277] Use new syntax for operators in .hlint.yaml

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -286,7 +286,7 @@
 - warn: { name: "Use 'empty' from Universum"
         , lhs: Control.Applicative.empty, rhs: Universum.empty }
 - warn: { name: "Use '(<|>)' from Universum"
-        , lhs: Control.Applicative.(<|>), rhs: Universum.(<|>) }
+        , lhs: (Control.Applicative.<|>), rhs: (Universum.<|>) }
 - warn: { name: "Use 'some' from Universum"
         , lhs: Control.Applicative.some, rhs: Universum.some }
 - warn: { name: "Use 'many' from Universum"
@@ -306,7 +306,7 @@
 - warn: { name: "Use 'optional' from Universum"
         , lhs: Control.Applicative.optional, rhs: Universum.optional }
 - warn: { name: "Use '(<**>)' from Universum"
-        , lhs: Control.Applicative.(<**>), rhs: Universum.(<**>) }
+        , lhs: (Control.Applicative.<**>), rhs: (Universum.<**>) }
 
 ## Base
 - warn: { name: "Use 'xor' from Universum"
@@ -532,7 +532,7 @@
 - warn: { name: "Use 'force' from Universum"
         , lhs: Control.DeepSeq.force, rhs: Universum.force }
 - warn: { name: "Use '($!!)' from Universum"
-        , lhs: "Control.DeepSeq.($!!)", rhs: "Universum.($!!)" }
+        , lhs: "(Control.DeepSeq.$!!)", rhs: "(Universum.$!!)" }
 
 ## Exception
 - warn: { name: "Use 'Exception' from Universum"
@@ -593,7 +593,7 @@
 
 ## Functor
 - warn: { name: "Use '(&&&)' from Universum"
-        , lhs: Control.Arrow.(&&&), rhs: Universum.(&&&) }
+        , lhs: (Control.Arrow.&&&), rhs: (Universum.&&&) }
 - warn: { name: "Use 'Bifunctor' from Universum"
         , lhs: Data.Bifunctor.Bifunctor, rhs: Universum.Bifunctor }
 - warn: { name: "Use 'bimap' from Universum"
@@ -605,7 +605,7 @@
 - warn: { name: "Use 'void' from Universum"
         , lhs: Data.Functor.void, rhs: Universum.void }
 - warn: { name: "Use '($>)' from Universum"
-        , lhs: Data.Functor.($>), rhs: Universum.($>) }
+        , lhs: (Data.Functor.$>), rhs: (Universum.$>) }
 - warn: { name: "Use 'Compose' from Universum"
         , lhs: Data.Functor.Compose.Compose, rhs: Universum.Compose }
 - warn: { name: "Use 'getCompose' from Universum"
@@ -656,7 +656,7 @@
 - warn: { name: "Use 'NonEmpty' from Universum"
         , lhs: Data.List.NonEmpty.NonEmpty, rhs: Universum.NonEmpty }
 - warn: { name: "Use '(:|)' from Universum"
-        , lhs: "Data.List.NonEmpty.(:|)", rhs: "Universum.(:|)"}
+        , lhs: "(Data.List.NonEmpty.:|)", rhs: "(Universum.:|)"}
 - warn: { name: "Use 'nonEmpty' from Universum"
         , lhs: Data.List.NonEmpty.nonEmpty, rhs: Universum.nonEmpty}
 - warn: { name: "Use 'head' from Universum"
@@ -672,9 +672,9 @@
 
 ## Monad
 - warn: { name: "Use '(>=>)' from Universum"
-        , lhs: Control.Monad.(>=>), rhs: Universum.(>=>) }
+        , lhs: (Control.Monad.>=>), rhs: (Universum.>=>) }
 - warn: { name: "Use '(<=<)' from Universum"
-        , lhs: Control.Monad.(<=<), rhs: Universum.(<=<) }
+        , lhs: (Control.Monad.<=<), rhs: (Universum.<=<) }
 - warn: { name: "Use 'forever' from Universum"
         , lhs: Control.Monad.forever, rhs: Universum.forever }
 - warn: { name: "Use 'join' from Universum"
@@ -708,7 +708,7 @@
 - warn: { name: "Use 'ap' from Universum"
         , lhs: Control.Monad.ap, rhs: Universum.ap }
 - warn: { name: "Use '(<$!>)' from Universum"
-        , lhs: Control.Monad.(<$!>), rhs: Universum.(<$!>) }
+        , lhs: (Control.Monad.<$!>), rhs: (Universum.<$!>) }
 
 - warn: { name: "Use 'ExceptT' from Universum"
         , lhs: Control.Monad.Except.ExceptT, rhs: Universum.ExceptT }
@@ -875,7 +875,7 @@
 - warn: { name: "Use 'stimes' from Universum"
         , lhs: Data.Semigroup.stimes, rhs: Universum.stimes }
 - warn: { name: "Use '(<>)' from Universum"
-        , lhs: Data.Semigroup.(<>), rhs: Universum.(<>) }
+        , lhs: (Data.Semigroup.<>), rhs: (Universum.<>) }
 - warn: { name: "Use 'WrappedMonoid' from Universum"
         , lhs: Data.Semigroup.WrappedMonoid, rhs: Universum.WrappedMonoid }
 - warn: { name: "Use 'cycle1' from Universum"
@@ -962,7 +962,7 @@
         , lhs: Data.List.last, rhs: Universum.Unsafe.last
         , note: "Use 'import qualified Universum.Unsafe as Unsafe (last)'" }
 - warn: { name: "Use '(!!)' from Universum.Unsafe"
-        , lhs: "Data.List.(!!)", rhs: "Universum.Unsafe.(!!)"
+        , lhs: "(Data.List.!!)", rhs: "(Universum.Unsafe.!!)"
         , note: "Use 'import qualified Universum.Unsafe as Unsafe ((!!))'" }
 - warn: { name: "Use 'fromJust' from Universum.Unsafe"
         , lhs: "Data.Maybe.fromJust", rhs: "Universum.Unsafe.fromJust"


### PR DESCRIPTION
## Description
Problem: our `.hlint.yaml` uses old syntax for rules that suggest / warn about operator usage, which produces parse errors if newest hlint-3.5 is used.

Solution: as in #277, we should move braces, e.g. use `(Control.Applicative.<|>)` instead of `Control.Applicative.(<|>)`



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->

Fixed #277

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If I added/removed/deprecated functions/re-exports,
      I checked whether these changes impact the [`.hlint.yaml`](https://github.com/serokell/universum/tree/master/.hlint.yaml) rules
      and updated them if needed.

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](https://github.com/serokell/universum/tree/master/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
