### PR TITLE
[#279] Fix some HLint rules

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -141,137 +141,137 @@
 
 # Probably will be reduced when function equality is done:
 # https://github.com/ndmitchell/hlint/issues/434
-- warn: {lhs: (case m of Just x -> f x; Nothing -> pure ()  ), rhs: Universum.whenJust m f}
-- warn: {lhs: (case m of Just x -> f x; Nothing -> return ()), rhs: Universum.whenJust m f}
-- warn: {lhs: (case m of Just x -> f x; Nothing -> pass     ), rhs: Universum.whenJust m f}
-- warn: {lhs: (case m of Nothing -> pure ()  ; Just x -> f x), rhs: Universum.whenJust m f}
-- warn: {lhs: (case m of Nothing -> return (); Just x -> f x), rhs: Universum.whenJust m f}
-- warn: {lhs: (case m of Nothing -> pass     ; Just x -> f x), rhs: Universum.whenJust m f}
-- warn: {lhs: (maybe (pure ())   f m), rhs: Universum.whenJust m f}
-- warn: {lhs: (maybe (return ()) f m), rhs: Universum.whenJust m f}
-- warn: {lhs: (maybe pass        f m), rhs: Universum.whenJust m f}
+- warn: {lhs: case m of Just x -> f x; Nothing -> pure ()  , rhs: Universum.whenJust m f}
+- warn: {lhs: case m of Just x -> f x; Nothing -> return (), rhs: Universum.whenJust m f}
+- warn: {lhs: case m of Just x -> f x; Nothing -> pass     , rhs: Universum.whenJust m f}
+- warn: {lhs: case m of Nothing -> pure ()  ; Just x -> f x, rhs: Universum.whenJust m f}
+- warn: {lhs: case m of Nothing -> return (); Just x -> f x, rhs: Universum.whenJust m f}
+- warn: {lhs: case m of Nothing -> pass     ; Just x -> f x, rhs: Universum.whenJust m f}
+- warn: {lhs: maybe (pure ())   f m, rhs: Universum.whenJust m f}
+- warn: {lhs: maybe (return ()) f m, rhs: Universum.whenJust m f}
+- warn: {lhs: maybe pass        f m, rhs: Universum.whenJust m f}
 
-- warn: {lhs: (m >>= \case Just x -> f x; Nothing -> pure ()  ), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= \case Just x -> f x; Nothing -> return ()), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= \case Just x -> f x; Nothing -> pass     ), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= \case Nothing -> pure ()  ; Just x -> f x), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= \case Nothing -> return (); Just x -> f x), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= \case Nothing -> pass     ; Just x -> f x), rhs: Universum.whenJustM m f}
-- warn: {lhs: (maybe (pure ())   f =<< m), rhs: Universum.whenJustM m f}
-- warn: {lhs: (maybe (return ()) f =<< m), rhs: Universum.whenJustM m f}
-- warn: {lhs: (maybe pass        f =<< m), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= maybe (pure ())   f), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= maybe (return ()) f), rhs: Universum.whenJustM m f}
-- warn: {lhs: (m >>= maybe pass        f), rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= \case Just x -> f x; Nothing -> pure ()  , rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= \case Just x -> f x; Nothing -> return (), rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= \case Just x -> f x; Nothing -> pass     , rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= \case Nothing -> pure ()  ; Just x -> f x, rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= \case Nothing -> return (); Just x -> f x, rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= \case Nothing -> pass     ; Just x -> f x, rhs: Universum.whenJustM m f}
+- warn: {lhs: maybe (pure ())   f =<< m, rhs: Universum.whenJustM m f}
+- warn: {lhs: maybe (return ()) f =<< m, rhs: Universum.whenJustM m f}
+- warn: {lhs: maybe pass        f =<< m, rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= maybe (pure ())   f, rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= maybe (return ()) f, rhs: Universum.whenJustM m f}
+- warn: {lhs: m >>= maybe pass        f, rhs: Universum.whenJustM m f}
 
-- warn: {lhs: (case m of Just _ -> pure ()  ; Nothing -> x), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (case m of Just _ -> return (); Nothing -> x), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (case m of Just _ -> pass     ; Nothing -> x), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (case m of Nothing -> x; Just _ -> pure ()  ), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (case m of Nothing -> x; Just _ -> return ()), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (case m of Nothing -> x; Just _ -> pass     ), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (maybe x (\_ -> pure ()    ) m), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (maybe x (\_ -> return ()  ) m), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (maybe x (\_ -> pass       ) m), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (maybe x (const (pure ()  )) m), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (maybe x (const (return ())) m), rhs: Universum.whenNothing_ m x}
-- warn: {lhs: (maybe x (const (pass     )) m), rhs: Universum.whenNothing_ m x}
+- warn: {lhs: case m of Just _ -> pure ()  ; Nothing -> x, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: case m of Just _ -> return (); Nothing -> x, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: case m of Just _ -> pass     ; Nothing -> x, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: case m of Nothing -> x; Just _ -> pure ()  , rhs: Universum.whenNothing_ m x}
+- warn: {lhs: case m of Nothing -> x; Just _ -> return (), rhs: Universum.whenNothing_ m x}
+- warn: {lhs: case m of Nothing -> x; Just _ -> pass     , rhs: Universum.whenNothing_ m x}
+- warn: {lhs: maybe x (\_ -> pure ()    ) m, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: maybe x (\_ -> return ()  ) m, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: maybe x (\_ -> pass       ) m, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: maybe x (const (pure ()  )) m, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: maybe x (const (return ())) m, rhs: Universum.whenNothing_ m x}
+- warn: {lhs: maybe x (const (pass     )) m, rhs: Universum.whenNothing_ m x}
 
-- warn: {lhs: (m >>= \case Just _ -> pure ()  ; Nothing -> x), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= \case Just _ -> return (); Nothing -> x), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= \case Just _ -> pass     ; Nothing -> x), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= \case Nothing -> x; Just _ -> pure ()  ), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= \case Nothing -> x; Just _ -> return ()), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= \case Nothing -> x; Just _ -> pass     ), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (maybe x (\_ -> pure ()    ) =<< m), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (maybe x (\_ -> return ()  ) =<< m), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (maybe x (\_ -> pass       ) =<< m), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (maybe x (const (pure ()  )) =<< m), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (maybe x (const (return ())) =<< m), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (maybe x (const (pass     )) =<< m), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= maybe x (\_ -> pure ())    ), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= maybe x (\_ -> return ())  ), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= maybe x (\_ -> pass)       ), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= maybe x (const (pure ())  )), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= maybe x (const (return ()))), rhs: Universum.whenNothingM_ m x}
-- warn: {lhs: (m >>= maybe x (const (pass)     )), rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= \case Just _ -> pure ()  ; Nothing -> x, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= \case Just _ -> return (); Nothing -> x, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= \case Just _ -> pass     ; Nothing -> x, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= \case Nothing -> x; Just _ -> pure ()  , rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= \case Nothing -> x; Just _ -> return (), rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= \case Nothing -> x; Just _ -> pass     , rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: maybe x (\_ -> pure ()    ) =<< m, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: maybe x (\_ -> return ()  ) =<< m, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: maybe x (\_ -> pass       ) =<< m, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: maybe x (const (pure ()  )) =<< m, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: maybe x (const (return ())) =<< m, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: maybe x (const (pass     )) =<< m, rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= maybe x (\_ -> pure ())    , rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= maybe x (\_ -> return ())  , rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= maybe x (\_ -> pass)       , rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= maybe x (const (pure ())  ), rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= maybe x (const (return ())), rhs: Universum.whenNothingM_ m x}
+- warn: {lhs: m >>= maybe x (const (pass)     ), rhs: Universum.whenNothingM_ m x}
 
-- warn: {lhs: (case m of Left x -> f x; Right _ -> pure ()  ), rhs: Universum.whenLeft m f}
-- warn: {lhs: (case m of Left x -> f x; Right _ -> return ()), rhs: Universum.whenLeft m f}
-- warn: {lhs: (case m of Left x -> f x; Right _ -> pass     ), rhs: Universum.whenLeft m f}
-- warn: {lhs: (case m of Right _ -> pure ()  ; Left x -> f x), rhs: Universum.whenLeft m f}
-- warn: {lhs: (case m of Right _ -> return (); Left x -> f x), rhs: Universum.whenLeft m f}
-- warn: {lhs: (case m of Right _ -> pass     ; Left x -> f x), rhs: Universum.whenLeft m f}
-- warn: {lhs: (either f (\_ -> pure ()    ) m), rhs: Universum.whenLeft m f}
-- warn: {lhs: (either f (\_ -> return ()  ) m), rhs: Universum.whenLeft m f}
-- warn: {lhs: (either f (\_ -> pass       ) m), rhs: Universum.whenLeft m f}
-- warn: {lhs: (either f (const (pure ()  )) m), rhs: Universum.whenLeft m f}
-- warn: {lhs: (either f (const (return ())) m), rhs: Universum.whenLeft m f}
-- warn: {lhs: (either f (const (pass     )) m), rhs: Universum.whenLeft m f}
+- warn: {lhs: case m of Left x -> f x; Right _ -> pure ()  , rhs: Universum.whenLeft m f}
+- warn: {lhs: case m of Left x -> f x; Right _ -> return (), rhs: Universum.whenLeft m f}
+- warn: {lhs: case m of Left x -> f x; Right _ -> pass     , rhs: Universum.whenLeft m f}
+- warn: {lhs: case m of Right _ -> pure ()  ; Left x -> f x, rhs: Universum.whenLeft m f}
+- warn: {lhs: case m of Right _ -> return (); Left x -> f x, rhs: Universum.whenLeft m f}
+- warn: {lhs: case m of Right _ -> pass     ; Left x -> f x, rhs: Universum.whenLeft m f}
+- warn: {lhs: either f (\_ -> pure ()    ) m, rhs: Universum.whenLeft m f}
+- warn: {lhs: either f (\_ -> return ()  ) m, rhs: Universum.whenLeft m f}
+- warn: {lhs: either f (\_ -> pass       ) m, rhs: Universum.whenLeft m f}
+- warn: {lhs: either f (const (pure ()  )) m, rhs: Universum.whenLeft m f}
+- warn: {lhs: either f (const (return ())) m, rhs: Universum.whenLeft m f}
+- warn: {lhs: either f (const (pass     )) m, rhs: Universum.whenLeft m f}
 
-- warn: {lhs: (m >>= \case Left x -> f x; Right _ -> pure ()  ), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= \case Left x -> f x; Right _ -> return ()), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= \case Left x -> f x; Right _ -> pass     ), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= \case Right _ -> pure ()  ; Left x -> f x), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= \case Right _ -> return (); Left x -> f x), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= \case Right _ -> pass     ; Left x -> f x), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (either f (\_ -> pure ()    ) =<< m), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (either f (\_ -> return ()  ) =<< m), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (either f (\_ -> pass       ) =<< m), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (either f (const (pure ()  )) =<< m), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (either f (const (return ())) =<< m), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (either f (const (pass     )) =<< m), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= either f (\_ -> pure ())    ), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= either f (\_ -> return ())  ), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= either f (\_ -> pass)       ), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= either f (const (pure ())  )), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= either f (const (return ()))), rhs: Universum.whenLeftM m f}
-- warn: {lhs: (m >>= either f (const (pass)     )), rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= \case Left x -> f x; Right _ -> pure ()  , rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= \case Left x -> f x; Right _ -> return (), rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= \case Left x -> f x; Right _ -> pass     , rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= \case Right _ -> pure ()  ; Left x -> f x, rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= \case Right _ -> return (); Left x -> f x, rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= \case Right _ -> pass     ; Left x -> f x, rhs: Universum.whenLeftM m f}
+- warn: {lhs: either f (\_ -> pure ()    ) =<< m, rhs: Universum.whenLeftM m f}
+- warn: {lhs: either f (\_ -> return ()  ) =<< m, rhs: Universum.whenLeftM m f}
+- warn: {lhs: either f (\_ -> pass       ) =<< m, rhs: Universum.whenLeftM m f}
+- warn: {lhs: either f (const (pure ()  )) =<< m, rhs: Universum.whenLeftM m f}
+- warn: {lhs: either f (const (return ())) =<< m, rhs: Universum.whenLeftM m f}
+- warn: {lhs: either f (const (pass     )) =<< m, rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= either f (\_ -> pure ())    , rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= either f (\_ -> return ())  , rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= either f (\_ -> pass)       , rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= either f (const (pure ())  ), rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= either f (const (return ())), rhs: Universum.whenLeftM m f}
+- warn: {lhs: m >>= either f (const (pass)     ), rhs: Universum.whenLeftM m f}
 
-- warn: {lhs: (case m of Right x -> f x; Left _ -> pure ()  ), rhs: Universum.whenRight m f}
-- warn: {lhs: (case m of Right x -> f x; Left _ -> return ()), rhs: Universum.whenRight m f}
-- warn: {lhs: (case m of Right x -> f x; Left _ -> pass     ), rhs: Universum.whenRight m f}
-- warn: {lhs: (case m of Left _ -> pure ()  ; Right x -> f x), rhs: Universum.whenRight m f}
-- warn: {lhs: (case m of Left _ -> return (); Right x -> f x), rhs: Universum.whenRight m f}
-- warn: {lhs: (case m of Left _ -> pass     ; Right x -> f x), rhs: Universum.whenRight m f}
-- warn: {lhs: (either (\_ -> pure ()    ) f m), rhs: Universum.whenRight m f}
-- warn: {lhs: (either (\_ -> return ()  ) f m), rhs: Universum.whenRight m f}
-- warn: {lhs: (either (\_ -> pass       ) f m), rhs: Universum.whenRight m f}
-- warn: {lhs: (either (const (pure ()  )) f m), rhs: Universum.whenRight m f}
-- warn: {lhs: (either (const (return ())) f m), rhs: Universum.whenRight m f}
-- warn: {lhs: (either (const (pass     )) f m), rhs: Universum.whenRight m f}
+- warn: {lhs: case m of Right x -> f x; Left _ -> pure ()  , rhs: Universum.whenRight m f}
+- warn: {lhs: case m of Right x -> f x; Left _ -> return (), rhs: Universum.whenRight m f}
+- warn: {lhs: case m of Right x -> f x; Left _ -> pass     , rhs: Universum.whenRight m f}
+- warn: {lhs: case m of Left _ -> pure ()  ; Right x -> f x, rhs: Universum.whenRight m f}
+- warn: {lhs: case m of Left _ -> return (); Right x -> f x, rhs: Universum.whenRight m f}
+- warn: {lhs: case m of Left _ -> pass     ; Right x -> f x, rhs: Universum.whenRight m f}
+- warn: {lhs: either (\_ -> pure ()    ) f m, rhs: Universum.whenRight m f}
+- warn: {lhs: either (\_ -> return ()  ) f m, rhs: Universum.whenRight m f}
+- warn: {lhs: either (\_ -> pass       ) f m, rhs: Universum.whenRight m f}
+- warn: {lhs: either (const (pure ()  )) f m, rhs: Universum.whenRight m f}
+- warn: {lhs: either (const (return ())) f m, rhs: Universum.whenRight m f}
+- warn: {lhs: either (const (pass     )) f m, rhs: Universum.whenRight m f}
 
-- warn: {lhs: (m >>= \case Right x -> f x; Left _ -> pure ()  ), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= \case Right x -> f x; Left _ -> return ()), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= \case Right x -> f x; Left _ -> pass     ), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= \case Left _ -> pure ()  ; Right x -> f x), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= \case Left _ -> return (); Right x -> f x), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= \case Left _ -> pass     ; Right x -> f x), rhs: Universum.whenRightM m f}
-- warn: {lhs: (either (\_ -> pure ()    ) f =<< m), rhs: Universum.whenRightM m f}
-- warn: {lhs: (either (\_ -> return ()  ) f =<< m), rhs: Universum.whenRightM m f}
-- warn: {lhs: (either (\_ -> pass       ) f =<< m), rhs: Universum.whenRightM m f}
-- warn: {lhs: (either (const (pure ()  )) f =<< m), rhs: Universum.whenRightM m f}
-- warn: {lhs: (either (const (return ())) f =<< m), rhs: Universum.whenRightM m f}
-- warn: {lhs: (either (const (pass     )) f =<< m), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= either (\_ -> pure ())     f), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= either (\_ -> return ())   f), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= either (\_ -> pass)        f), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= either (const (pure ())  ) f), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= either (const (return ())) f), rhs: Universum.whenRightM m f}
-- warn: {lhs: (m >>= either (const (pass)     ) f), rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= \case Right x -> f x; Left _ -> pure ()  , rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= \case Right x -> f x; Left _ -> return (), rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= \case Right x -> f x; Left _ -> pass     , rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= \case Left _ -> pure ()  ; Right x -> f x, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= \case Left _ -> return (); Right x -> f x, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= \case Left _ -> pass     ; Right x -> f x, rhs: Universum.whenRightM m f}
+- warn: {lhs: either (\_ -> pure ()    ) f =<< m, rhs: Universum.whenRightM m f}
+- warn: {lhs: either (\_ -> return ()  ) f =<< m, rhs: Universum.whenRightM m f}
+- warn: {lhs: either (\_ -> pass       ) f =<< m, rhs: Universum.whenRightM m f}
+- warn: {lhs: either (const (pure ()  )) f =<< m, rhs: Universum.whenRightM m f}
+- warn: {lhs: either (const (return ())) f =<< m, rhs: Universum.whenRightM m f}
+- warn: {lhs: either (const (pass     )) f =<< m, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= either (\_ -> pure ())     f, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= either (\_ -> return ())   f, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= either (\_ -> pass)        f, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= either (const (pure ())  ) f, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= either (const (return ())) f, rhs: Universum.whenRightM m f}
+- warn: {lhs: m >>= either (const (pass)     ) f, rhs: Universum.whenRightM m f}
 
-- warn: {lhs: "(case m of [] -> return (); (x:xs) -> f (x :| xs))", rhs: Universum.whenNotNull m f}
-- warn: {lhs: "(case m of [] -> pure ()  ; (x:xs) -> f (x :| xs))", rhs: Universum.whenNotNull m f}
-- warn: {lhs: "(case m of [] -> pass     ; (x:xs) -> f (x :| xs))", rhs: Universum.whenNotNull m f}
-- warn: {lhs: "(case m of (x:xs) -> f (x :| xs); [] -> return ())", rhs: Universum.whenNotNull m f}
-- warn: {lhs: "(case m of (x:xs) -> f (x :| xs); [] -> pure ()  )", rhs: Universum.whenNotNull m f}
-- warn: {lhs: "(case m of (x:xs) -> f (x :| xs); [] -> pass     )", rhs: Universum.whenNotNull m f}
-- warn: {lhs: "(m >>= \\case [] -> pass     ; (x:xs) -> f (x :| xs))", rhs: Universum.whenNotNullM m f}
-- warn: {lhs: "(m >>= \\case [] -> pure ()  ; (x:xs) -> f (x :| xs))", rhs: Universum.whenNotNullM m f}
-- warn: {lhs: "(m >>= \\case [] -> return (); (x:xs) -> f (x :| xs))", rhs: Universum.whenNotNullM m f}
-- warn: {lhs: "(m >>= \\case (x:xs) -> f (x :| xs); [] -> pass     )", rhs: Universum.whenNotNullM m f}
-- warn: {lhs: "(m >>= \\case (x:xs) -> f (x :| xs); [] -> pure ()  )", rhs: Universum.whenNotNullM m f}
-- warn: {lhs: "(m >>= \\case (x:xs) -> f (x :| xs); [] -> return ())", rhs: Universum.whenNotNullM m f}
+- warn: {lhs: "case m of [] -> return (); (x:xs) -> f (x :| xs)", rhs: Universum.whenNotNull m f}
+- warn: {lhs: "case m of [] -> pure ()  ; (x:xs) -> f (x :| xs)", rhs: Universum.whenNotNull m f}
+- warn: {lhs: "case m of [] -> pass     ; (x:xs) -> f (x :| xs)", rhs: Universum.whenNotNull m f}
+- warn: {lhs: "case m of (x:xs) -> f (x :| xs); [] -> return ()", rhs: Universum.whenNotNull m f}
+- warn: {lhs: "case m of (x:xs) -> f (x :| xs); [] -> pure ()  ", rhs: Universum.whenNotNull m f}
+- warn: {lhs: "case m of (x:xs) -> f (x :| xs); [] -> pass     ", rhs: Universum.whenNotNull m f}
+- warn: {lhs: "m >>= \\case [] -> pass     ; (x:xs) -> f (x :| xs)", rhs: Universum.whenNotNullM m f}
+- warn: {lhs: "m >>= \\case [] -> pure ()  ; (x:xs) -> f (x :| xs)", rhs: Universum.whenNotNullM m f}
+- warn: {lhs: "m >>= \\case [] -> return (); (x:xs) -> f (x :| xs)", rhs: Universum.whenNotNullM m f}
+- warn: {lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> pass     ", rhs: Universum.whenNotNullM m f}
+- warn: {lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> pure ()  ", rhs: Universum.whenNotNullM m f}
+- warn: {lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> return ()", rhs: Universum.whenNotNullM m f}
 
 - warn: {lhs: mapMaybe leftToMaybe, rhs: lefts}
 - warn: {lhs: mapMaybe rightToMaybe, rhs: rights}


### PR DESCRIPTION
## Description

Problem:
As in #277, some of our HLint rules have parenthesized lhs, e.g.
```
- warn: {lhs: (maybe pass f m), rhs: Universum.whenJust m f}
```
Such rules are triggering only on parnthisized code, e.g. rule above is not triggering on `x = maybe pass f m`.
Of course, we want to suggest `whenJust` in this case.

Solution:
Remove extra parenthesis in such rules, test this solves issue and is not leading to false reports.
Tested using HLint 3.5 (lastest) and 3.3.6



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->

Fixed #279

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If I added/removed/deprecated functions/re-exports,
      I checked whether these changes impact the [`.hlint.yaml`](https://github.com/serokell/universum/tree/master/.hlint.yaml) rules
      and updated them if needed.

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](https://github.com/serokell/universum/tree/master/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).
