### PR TITLE
[#281] Allow text-2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Unreleased
 1.8.0
 =====
 
+* [#282](https://github.com/serokell/universum/pull/282):
+  Bump version bound on `text` to `2.0.1`.
+
 * [#252](https://github.com/serokell/universum/pull/252):
   Remove `Option` re-export. Use `Maybe` instead.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,17 @@
-Unreleased
-=====
-
-1.8.0
-=====
+1.8.1.1
+=======
 
 * [#282](https://github.com/serokell/universum/pull/282):
   Bump version bound on `text` to `2.0.1`.
+
+1.8.1
+=====
+
+* [#271](https://github.com/serokell/universum/pull/271):
+  Add compatibility with tasty-hedgehog 1.2.0.0
+
+1.8.0
+=====
 
 * [#252](https://github.com/serokell/universum/pull/252):
   Remove `Option` re-export. Use `Maybe` instead.

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -180,11 +180,8 @@ bgroupFold = do
 bgroupTextConversion :: Benchmark
 bgroupTextConversion =
   bgroup "text conversions"
-    [ let str = replicate 100000 'a'
-          countLength x = length (toString x)
-      in bench "toString . toText" $ whnf (countLength . toText) str
-
-    , let txt = T.replicate 100000 (T.singleton 'a')
-          countLength x = length (toText x)
-      in bench "toText . toString" $ whnf (countLength . toString) txt
+    [ -- With @toText . toString -> id@ rewrite rules we expect ~10ns
+      -- Without the rules: >10ms
+      let txt = T.replicate 10000000 (T.singleton 'a')
+      in bench "toText . toString" $ whnf (toText . toString) txt
     ]

--- a/src/Universum/String/Conversion.hs
+++ b/src/Universum/String/Conversion.hs
@@ -248,7 +248,7 @@ Aha, so it's mapping some codepoints to @'\xfffd'@!
 There's a comment on top of it to explain this:
 
 ```
--- UTF-16 surrogate code points are not included in the set of Unicode
+-- Unicode 'Data.Char.Surrogate' code points are not included in the set of Unicode
 -- scalar values, but are unfortunately admitted as valid 'Char'
 -- values by Haskell.  They cannot be represented in a 'Text'.  This
 -- function remaps those code points to the Unicode replacement

--- a/src/Universum/String/Conversion.hs
+++ b/src/Universum/String/Conversion.hs
@@ -194,6 +194,8 @@ seeing if implementation of any of these functions have changed:
   * unstreamList
   * safe
   * any RULES definition (if some is added, this counts)
+Also check the @text conversions@ benchmark, that the numbers with and without
+the rules are still the expected ones
 If none of mentioned have changed, then it is safe to assume that everything
 is still fine.
 

--- a/universum.cabal
+++ b/universum.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                universum
-version:             1.8.1
+version:             1.8.1.1
 synopsis:            Custom prelude used in Serokell
 description:         See README.md file for more details.
 homepage:            https://github.com/serokell/universum

--- a/universum.cabal
+++ b/universum.cabal
@@ -105,7 +105,7 @@ library
                      , stm
                      -- Make sure that "toString-toText-rewritting" note
                      -- is still valid when bumping this constraint.
-                     , text >= 1.0.0.0 && <= 1.2.5.0
+                     , text >= 1.0.0.0 && <= 2.0.1
                      , transformers
                      , unordered-containers
                      , utf8-string


### PR DESCRIPTION
## Description

Increase the version upper bound on `text` package.

The related logic (`pack`, `unpack`) seems to be untouched, and the rewrite rule speeds up a call of `toString . toText`.

## Related issues(s)

Fixed #281 

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If I added/removed/deprecated functions/re-exports,
      I checked whether these changes impact the [`.hlint.yaml`](https://github.com/serokell/universum/tree/master/.hlint.yaml) rules
      and updated them if needed.

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](https://github.com/serokell/universum/tree/master/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).

## ✓ Release Checklist

- [x] I updated the version number in `universum.cabal`.
- [x] I updated the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [x] If any definitions (functions, type classes, instances, etc) were added,
      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/universum/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y.Z`
