### PR TITLE
[#285] Bump `text` package after 2.0.1 (to 2.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Universum
 
 [![GitHub CI](https://github.com/serokell/universum/workflows/CI/badge.svg)](https://github.com/serokell/universum/actions)
 [![Hackage](https://img.shields.io/hackage/v/universum.svg)](https://hackage.haskell.org/package/universum)
-[![Stackage LTS](http://stackage.org/package/universum/badge/lts)](http://stackage.org/lts/package/universum)
-[![Stackage Nightly](http://stackage.org/package/universum/badge/nightly)](http://stackage.org/nightly/package/universum)
+<!-- TODO [#288]: enable these once -->
+<!-- [![Stackage LTS](http://stackage.org/package/universum/badge/lts)](http://stackage.org/lts/package/universum) -->
+<!-- [![Stackage Nightly](http://stackage.org/package/universum/badge/nightly)](http://stackage.org/nightly/package/universum) -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 `universum` is a custom prelude used in @Serokell that has:

--- a/test/Test/Universum/StringProps.hs
+++ b/test/Test/Universum/StringProps.hs
@@ -28,9 +28,7 @@ hprop_StringToTextAndBack = property $ do
   str <- forAll unicodeAllString
   toString (toText str) === str
 
--- | See comment to this function:
--- <http://hackage.haskell.org/package/text-1.2.3.1/docs/src/Data.Text.Internal.html#safe>
---
+-- |
 -- While 'String' may contain surrogate UTF-16 code points, actually UTF-8
 -- doesn't allow them, as well as 'Text'. 'Data.Text.pack' replaces invalid
 -- characters with unicode replacement character, so by default
@@ -41,7 +39,8 @@ hprop_StringToTextAndBack = property $ do
 hprop_StringToTextAndBackSurrogate :: Property
 hprop_StringToTextAndBackSurrogate = property $ do
   -- Surrogate character like this one should remain intact
-  -- Without rewrite rule this string would be transformed to "\9435"
+  -- Without the rewrite rule this string would be transformed to some other,
+  -- valid string
   let str = "\xD800"
   toString (toText str) === str
 

--- a/universum.cabal
+++ b/universum.cabal
@@ -105,7 +105,7 @@ library
                      , stm
                      -- Make sure that "toString-toText-rewritting" note
                      -- is still valid when bumping this constraint.
-                     , text >= 1.0.0.0 && <= 2.0.1
+                     , text >= 1.0.0.0 && <= 2.0.2
                      , transformers
                      , unordered-containers
                      , utf8-string


### PR DESCRIPTION
## Description

In the current `master` (after `2.0.1` version) `text` package changes implementation of `pack`, and this affects which rewrite rules should we use. After the new release, these and maybe some other changes will have to be applied.

## Related issues(s)

Resolves #285

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->


## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [ ] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [ ] If I added/removed/deprecated functions/re-exports,
      I checked whether these changes impact the [`.hlint.yaml`](https://github.com/serokell/universum/tree/master/.hlint.yaml) rules
      and updated them if needed.

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [ ] [README](https://github.com/serokell/universum/tree/master/README.md)
  - [ ] Haddock

- Record your changes

  - [ ] I added an entry to the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).

## ✓ Release Checklist

- [ ] I updated the version number in `universum.cabal`.
- [ ] I updated the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] If any definitions (functions, type classes, instances, etc) were added,
      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/universum/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y.Z`
