### PR TITLE
[#290] Add `Universum.Lens` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ Then, some commonly used types: `Map/HashMap/IntMap`, `Set/HashSet/IntSet`, `Seq
 `deepseq` is exported. For instance, if you want to force deep evaluation of some value (in IO),
 you can write `evaluateNF a`. WHNF evaluation is possible with `evaluateWHNF a`.
 
-We also reexport big chunks of these libraries: `mtl`, `stm`, `microlens`, `microlens-mtl`.
+`(.^)`, `(.~)` and some other optics-related functions and operators are exported in
+`Universum.Lens` module.
+This module is not included in `Universum` module so it requires explicit `import`.
+
+We also reexport big chunks of `mtl`, `stm`.
 
 [`Bifunctor`](http://hackage.haskell.org/package/base-4.9.1.0/docs/Data-Bifunctor.html)
 type class with useful instances is exported.

--- a/src/Universum.hs
+++ b/src/Universum.hs
@@ -43,6 +43,9 @@ Below is a short description of what you can find under different modules:
 * __"Universum.Function"__: almost everything from "Data.Function" module.
 * __"Universum.Functor"__: reexports from "Data.Functor", "Data.Bifunctor",
   other useful 'Functor' combinators.
+* __"Universum.Lens"__: Some operators and functions for using lenses.
+  Not exported by "Universum" module by default, so, if more functionality is needed,
+  @microlens@ or @lens@ packages can be used without conflicts of names.
 * __"Universum.Lifted"__: lifted to 'MonadIO' functions to work with console,
   files, 'IORef's, 'MVar's, etc.
 * __"Universum.List"__: big chunk of "Data.List", 'NonEmpty' type and
@@ -80,18 +83,7 @@ module Universum
        , module Universum.TypeOps
        , module Universum.VarArg
 
-         -- * Lenses
-       , Lens
-       , Lens'
-       , Traversal
-       , Traversal'
-       , over
-       , set
-       , (%~)
-       , (.~)
-       , (^.)
-       , (^..)
-       , (^?)
+         -- * Lenses, see also __"Universum.Lens"__
        , _1
        , _2
        , _3
@@ -123,24 +115,12 @@ import Universum.TypeOps
 import Universum.VarArg
 
 -- Lenses
-import qualified Lens.Micro (ASetter, Getting, over, set, (%~), (.~), (^.),
-                             (^..), (^?), _1, _2, _3, _4, _5)
+import qualified Lens.Micro (Getting, Lens, _1, _2, _3, _4, _5)
 import qualified Lens.Micro.Mtl (preuse, preview, use, view)
 import Lens.Micro.Internal (Field1, Field2, Field3, Field4, Field5)
 
 {-# DEPRECATED
-    Lens
-  , Lens'
-  , Traversal
-  , Traversal'
-  , over
-  , set
-  , (%~)
-  , (.~)
-  , (^.)
-  , (^..)
-  , (^?)
-  , _1
+    _1
   , _2
   , _3
   , _4
@@ -152,56 +132,19 @@ import Lens.Micro.Internal (Field1, Field2, Field3, Field4, Field5)
   "Use corresponding function from 'lens' or 'microlens' package"
 #-}
 
-type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
-type Lens' s a = Lens s s a a
-
-type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
-type Traversal' s a = Traversal s s a a
-
-over :: Lens.Micro.ASetter s t a b -> (a -> b) -> s -> t
-over = Lens.Micro.over
-
-set :: Lens.Micro.ASetter s t a b -> b -> s -> t
-set = Lens.Micro.set
-
-(%~) :: Lens.Micro.ASetter s t a b -> (a -> b) -> s -> t
-(%~) = (Lens.Micro.%~)
-
-infixr 4 %~
-
-(.~) :: Lens.Micro.ASetter s t a b -> b -> s -> t
-(.~) = (Lens.Micro..~)
-
-infixr 4 .~
-
-(^.) :: s -> Lens.Micro.Getting a s a -> a
-(^.) = (Lens.Micro.^.)
-
-infixl 8 ^.
-
-(^..) :: s -> Lens.Micro.Getting (Endo [a]) s a -> [a]
-(^..) = (Lens.Micro.^..)
-
-infixl 8 ^..
-
-(^?) :: s -> Lens.Micro.Getting (First a) s a -> Maybe a
-(^?) = (Lens.Micro.^?)
-
-infixl 8 ^?
-
-_1 :: Field1 s t a b => Lens s t a b
+_1 :: Field1 s t a b => Lens.Micro.Lens s t a b
 _1 = Lens.Micro._1
 
-_2 :: Field2 s t a b => Lens s t a b
+_2 :: Field2 s t a b => Lens.Micro.Lens s t a b
 _2 = Lens.Micro._2
 
-_3 :: Field3 s t a b => Lens s t a b
+_3 :: Field3 s t a b => Lens.Micro.Lens s t a b
 _3 = Lens.Micro._3
 
-_4 :: Field4 s t a b => Lens s t a b
+_4 :: Field4 s t a b => Lens.Micro.Lens s t a b
 _4 = Lens.Micro._4
 
-_5 :: Field5 s t a b => Lens s t a b
+_5 :: Field5 s t a b => Lens.Micro.Lens s t a b
 _5 = Lens.Micro._5
 
 preuse :: MonadState s m => Lens.Micro.Getting (First a) s a -> m (Maybe a)

--- a/src/Universum/Lens.hs
+++ b/src/Universum/Lens.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Safe       #-}
+
+-- | Operators and functions compatible with lens constructed with
+-- any of `lens` and `microlens` packages. Both those packages contain
+-- operators, types, and functions defined here, so you can find all related
+-- documentation there.
+
+module Universum.Lens
+       ( Lens
+       , Lens'
+       , Traversal
+       , Traversal'
+
+       , ASetter
+       , Getting
+
+       , over
+       , set
+       , get
+       , (%~)
+       , (.~)
+       , (^.)
+       , (^..)
+       , (^?)
+       ) where
+
+
+import Data.Maybe (Maybe (..))
+import Universum.Applicative
+import Universum.Function
+import Universum.Functor
+import Universum.Monoid
+
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+type Lens' s a = Lens s s a a
+
+type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
+type Traversal' s a = Traversal s s a a
+
+type ASetter s t a b = (a -> Identity b) -> s -> Identity t
+
+type Getting r s a = (a -> Const r a) -> s -> Const r s
+
+over :: ASetter s t a b -> (a -> b) -> s -> t
+over setter f = runIdentity . setter (Identity . f)
+
+set :: ASetter s t a b -> b -> s -> t
+set setter f = over setter (const f)
+
+get :: s -> Getting a s a -> a
+get s getter = getConst $ getter Const s
+
+(%~) ::ASetter s t a b -> (a -> b) -> s -> t
+(%~) = over
+
+infixr 4 %~
+
+(.~) :: ASetter s t a b -> b -> s -> t
+(.~) = set
+
+infixr 4 .~
+
+(^.) :: s -> Getting a s a -> a
+(^.) = get
+
+infixl 8 ^.
+
+(^..) :: s -> Getting (Endo [a]) s a -> [a]
+s ^.. getter =
+  let endo = getConst $ getter (\x -> Const $ Endo (x :)) s in
+  appEndo endo []
+
+infixl 8 ^..
+
+(^?) :: s -> Getting (First a) s a -> Maybe a
+s ^? getter = getFirst $ getConst $ getter (Const . pure) s
+
+infixl 8 ^?

--- a/universum.cabal
+++ b/universum.cabal
@@ -70,6 +70,7 @@ library
                            Universum.Functor
                                Universum.Functor.Fmap
                                Universum.Functor.Reexport
+                           Universum.Lens
                            Universum.Lifted
                                Universum.Lifted.Concurrent
                                Universum.Lifted.Env


### PR DESCRIPTION
## Description
Problem:
As in #290, we want to export lens-related operators like `(^.)` or `(^?)`, but we don't want to depend on `microlens` or `lens`.

Solution:
Implement those operators by ourselves, and export them in a separate module to avoid name conflicts.
Remove those operators from `Universum` reexports.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->


## Related issues(s)

<!--
- Short description how the PR relates to the issue, including an issue link.

For example

- Fixed #1 by adding lenses to exported items
-->

Fixed #290

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [ ] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [ ] If I added/removed/deprecated functions/re-exports,
      I checked whether these changes impact the [`.hlint.yaml`](https://github.com/serokell/universum/tree/master/.hlint.yaml) rules
      and updated them if needed.

#### Related changes (conditional)

- Tests

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [ ] [README](https://github.com/serokell/universum/tree/master/README.md)
  - [ ] Haddock

- Record your changes

  - [ ] I added an entry to the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) (creating the `Unreleased` section if necessary) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [ ] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).

## ✓ Release Checklist

- [ ] I updated the version number in `universum.cabal`.
- [ ] I updated the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [ ] If any definitions (functions, type classes, instances, etc) were added,
      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/universum/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y.Z`
