### PR TITLE
[#296] Support ghc-9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,18 @@ jobs:
           - "8.10.7"
           - "9.0.2"
           - "9.2.8"
-          - "9.4.5"
-          - "9.6.3"
-          - "9.8.1"
+          - "9.4.8"
+          - "9.6.6"
+          - "9.8.2"
           - "9.10.1"
         # Use only the "main" (usually latest) compiler version on non-Linux
         exclude:
           - os: macOS-latest
             ghc: 9.10.1
           - os: macOS-latest
-            ghc: 9.8.1
+            ghc: 9.8.2
           - os: macOS-latest
-            ghc: 9.4.5
+            ghc: 9.4.8
           - os: macOS-latest
             ghc: 9.2.8
           - os: macOS-latest
@@ -59,9 +59,9 @@ jobs:
           - os: windows-latest
             ghc: 9.10.1
           - os: windows-latest
-            ghc: 9.8.1
+            ghc: 9.8.2
           - os: windows-latest
-            ghc: 9.4.5
+            ghc: 9.4.8
           - os: windows-latest
             ghc: 9.2.8
           - os: windows-latest
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         stack: ["3.1.1"]
-        ghc: ["9.6.3"]
+        ghc: ["9.6.6"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.10"]
+        cabal: ["3.12"]
         # If you update this list of supported compiler versions,
         # make sure to update the `tested-with` section of `universum.cabal`.
         ghc:
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.13.1"]
+        stack: ["3.1.1"]
         ghc: ["9.6.3"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
           - "9.4.5"
           - "9.6.3"
           - "9.8.1"
+          - "9.10.1"
         # Use only the "main" (usually latest) compiler version on non-Linux
         exclude:
+          - os: macOS-latest
+            ghc: 9.10.1
           - os: macOS-latest
             ghc: 9.8.1
           - os: macOS-latest
@@ -53,6 +56,8 @@ jobs:
             ghc: 9.0.2
           - os: macOS-latest
             ghc: 8.10.7
+          - os: windows-latest
+            ghc: 9.10.1
           - os: windows-latest
             ghc: 9.8.1
           - os: windows-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.8.2.2
+=======
+
+* [#297](https://github.com/serokell/universum/pull/297)
+  * Add support for GHC-9.10 without any user-visible changes.
+
 1.8.2.1
 =======
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ to replace default `Prelude` with an alternative. All we had to do is to impleme
 new basic set of defaults. There already were plenty of [preludes](https://guide.aelve.com/haskell/alternative-preludes-zr69k1hc),
 so we didn't plan to implement everything from scratch.
 After some long, hot discussions, our team decided to base our custom prelude on
-[`protolude`](https://github.com/sdiehl/protolude). If you're not familiar with it,
-you can read [a tutorial about `protolude`](http://www.stephendiehl.com/posts/protolude.html).
+[`protolude`](https://github.com/protolude/protolude).
 
 The next section explains why we've made this choice and what we are willing to do.
 This tutorial doesn't cover the differences from `protolude`. Instead, it explains how Universum is different from regular `Prelude`.

--- a/src/Universum/Container/Class.hs
+++ b/src/Universum/Container/Class.hs
@@ -48,6 +48,9 @@ module Universum.Container.Class
 import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
 import Prelude hiding (all, and, any, concatMap, elem, foldMap, foldl, foldr, mapM_, notElem, null,
+#if __GLASGOW_HASKELL__ >= 910
+                foldl',
+#endif
                 or, print, product, sequence_, sum)
 
 import Universum.Applicative (Alternative (..), Const, ZipList (..), pass)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-22.4
+resolver: lts-22.38

--- a/universum.cabal
+++ b/universum.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                universum
-version:             1.8.2.1
+version:             1.8.2.2
 synopsis:            Custom prelude used in Serokell
 description:         See README.md file for more details.
 homepage:            https://github.com/serokell/universum

--- a/universum.cabal
+++ b/universum.cabal
@@ -16,9 +16,9 @@ bug-reports:         https://github.com/serokell/universum/issues
 tested-with:         GHC == 8.10.7
                    , GHC == 9.0.2
                    , GHC == 9.2.8
-                   , GHC == 9.4.5
-                   , GHC == 9.6.3
-                   , GHC == 9.8.1
+                   , GHC == 9.4.8
+                   , GHC == 9.6.6
+                   , GHC == 9.8.2
                    , GHC == 9.10.1
 extra-doc-files:     CHANGES.md
                    , CONTRIBUTING.md

--- a/universum.cabal
+++ b/universum.cabal
@@ -19,6 +19,7 @@ tested-with:         GHC == 8.10.7
                    , GHC == 9.4.5
                    , GHC == 9.6.3
                    , GHC == 9.8.1
+                   , GHC == 9.10.1
 extra-doc-files:     CHANGES.md
                    , CONTRIBUTING.md
                    , README.md

--- a/universum.cabal
+++ b/universum.cabal
@@ -179,6 +179,8 @@ benchmark universum-benchmark
   ghc-options:         -Wno-missing-safe-haskell-mode
   if impl(ghc >= 9.8.0)
     ghc-options:         -Wno-x-partial
+  -- TODO (#298): migrate from gauge to something
+  buildable: False
 
   default-extensions:  NoImplicitPrelude
                        ScopedTypeVariables


### PR DESCRIPTION
## Description

Problem: there is ghc-9.10 for a while, but we don't support it for several reasons.

Solution:
1. Ignore foldl' import from Prelude in one module if GHC version is 9.10 or newer. This export was added to Prelude in base-4.20.
2. Add 9.10.1 to tested-with.
3. Update the CI config accordingly. 9.6 is still considered as the main version (as it's used in the latest LTS resolver), so we use it for 3 OS.




## Related issues(s)

Resolves #296

## ✓ Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

- [x] I made sure my PR addresses a single concern, or multiple concerns which
      are inextricably linked. Otherwise I should open multiple PR's.
- [x] If I added/removed/deprecated functions/re-exports,
      I checked whether these changes impact the [`.hlint.yaml`](https://github.com/serokell/universum/tree/master/.hlint.yaml) rules
      and updated them if needed.

#### Related changes (conditional)

- Tests

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation

  I checked whether I should update the docs and did so if necessary:

  - [x] [README](https://github.com/serokell/universum/tree/master/README.md)
  - [x] Haddock

- Record your changes

  - [x] I added an entry to the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) (creating the `Unreleased` section if necessary) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commit history is clean (only contains changes relating to my
      issue/pull request and no reverted-my-earlier-commit changes) and commit
      messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).

## ✓ Release Checklist

- [x] I updated the version number in `universum.cabal`.
- [x] I updated the [changelog](https://github.com/serokell/universum/tree/master/CHANGES.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [x] If any definitions (functions, type classes, instances, etc) were added,
      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/universum/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y.Z`
